### PR TITLE
Skip tests that expect contiguous layout with DAOS VOL

### DIFF
--- a/vol_dataset_test.c
+++ b/vol_dataset_test.c
@@ -3118,10 +3118,18 @@ test_dataset_property_lists(void)
     hid_t       dset_dtype1 = H5I_INVALID_HID, dset_dtype2 = H5I_INVALID_HID, dset_dtype3 = H5I_INVALID_HID, dset_dtype4 = H5I_INVALID_HID;
     hid_t       space_id = H5I_INVALID_HID;
     char       *tmp_prefix = NULL;
+    char        vol_name[5];
 
     TESTING_MULTIPART("dataset property list operations");
 
     TESTING_2("test setup")
+
+    /** for DAOS VOL, this test is problematic since auto chunking can be selected, so skip for now */
+    if (H5VLget_connector_name(file_id, vol_name, 5) < 0) {
+        H5_FAILED();
+        HDprintf("    couldn't get VOL NAME '%s'\n", DATASET_TEST_GROUP_NAME);
+        goto error;
+    }
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -3227,7 +3235,8 @@ test_dataset_property_lists(void)
                     err_ret = H5Pget_chunk(dcpl_id2, DATASET_PROPERTY_LIST_TEST_SPACE_RANK, tmp_chunk_dims);
                 } H5E_END_TRY;
 
-                if (err_ret >= 0) {
+		/* DAOS VOL can auto chunk, so don't fail */
+		if (err_ret >= 0 && strcmp(vol_name, "daos") != 0) {
                     H5_FAILED();
                     HDprintf("    property list 2 shouldn't have had chunk dimensionality set (not a chunked layout)\n");
                     PART_ERROR(H5Dget_create_plist);
@@ -3410,7 +3419,8 @@ test_dataset_property_lists(void)
                     err_ret = H5Pget_chunk(dcpl_id2, DATASET_PROPERTY_LIST_TEST_SPACE_RANK, tmp_chunk_dims);
                 } H5E_END_TRY;
 
-                if (err_ret >= 0) {
+		/* DAOS VOL can auto chunk, so don't fail */
+		if (err_ret >= 0 && strcmp(vol_name, "daos") != 0) {
                     H5_FAILED();
                     HDprintf("    property list 2 shouldn't have had chunk dimensionality set (not a chunked layout)\n");
                     PART_ERROR(H5Dget_create_plist_reopened);
@@ -7770,8 +7780,20 @@ test_dataset_set_extent_invalid_params(void)
     hid_t   dset_dtype = H5I_INVALID_HID;
     hid_t   chunked_dcpl_id = H5I_INVALID_HID, compact_dcpl_id = H5I_INVALID_HID, contiguous_dcpl_id = H5I_INVALID_HID;
     hid_t   fspace_id = H5I_INVALID_HID, compact_fspace_id = H5I_INVALID_HID;
+    char   vol_name[5];
 
     TESTING_MULTIPART("H5Dset_extent with invalid parameters");
+
+    /** for DAOS VOL, this test is problematic since auto chunking can be selected, so skip for now */
+    if (H5VLget_connector_name(file_id, vol_name, 5) < 0) {
+        H5_FAILED();
+        HDprintf("    couldn't get VOL NAME '%s'\n", DATASET_TEST_GROUP_NAME);
+        goto error;
+    }
+    if (strcmp(vol_name, "daos") == 0) {
+        TESTING_2("Skipping test with DAOS VOL")
+	return 0;
+    }
 
     TESTING_2("test setup")
 


### PR DESCRIPTION
DAOS VOL does autochunking of contig datasets, so skip tests that expect contig layout with DAOS VOL.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>