### PR TITLE
Adding the verification of VOL cap flags to the tests

### DIFF
--- a/vol_async_test.c
+++ b/vol_async_test.c
@@ -2575,4 +2575,3 @@ vol_async_test(void)
 }
 
 #endif /* H5ESpublic_H */
-

--- a/vol_attribute_test.c
+++ b/vol_attribute_test.c
@@ -123,6 +123,13 @@ test_create_attribute_on_root(void)
 
     TESTING_MULTIPART("attribute creation on the root group");
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_ATTR_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file or attribute aren't supported with this connector\n");
+        return 0;
+    }
+
     TESTING_2("test setup")
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
@@ -244,6 +251,14 @@ test_create_attribute_on_dataset(void)
     hid_t  attr_space_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("attribute creation on a dataset");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |
+                           H5VL_CAP_FLAG_ATTR_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, dataset, or attribute aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -405,6 +420,14 @@ test_create_attribute_on_datatype(void)
 
     TESTING_MULTIPART("attribute creation on a committed datatype");
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_STORED_DATATYPES |
+                           H5VL_CAP_FLAG_ATTR_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, stored datatype, or attribute aren't supported with this connector\n");
+        return 0;
+    }
+
     TESTING_2("test setup")
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
@@ -557,6 +580,13 @@ test_create_attribute_with_null_space(void)
 
     TESTING("attribute creation with a NULL dataspace")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_ATTR_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or attribute aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file\n");
@@ -655,6 +685,13 @@ test_create_attribute_with_scalar_space(void)
     hid_t  space_id = H5I_INVALID_HID;
 
     TESTING("attribute creation with a SCALAR dataspace")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_ATTR_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or attribute aren't supported with this connector\n");
+        return 0;
+    }
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -757,6 +794,13 @@ test_create_attribute_with_space_in_name(void)
 
     TESTING("attribute creation with a space in attribute's name")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_ATTR_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or attribute aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file\n");
@@ -846,6 +890,13 @@ test_create_attribute_invalid_params(void)
     hid_t  space_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("attribute creation with invalid parameters");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_ATTR_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or attribute aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -1221,6 +1272,13 @@ test_open_attribute(void)
 
     TESTING_MULTIPART("attribute opening");
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_ATTR_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or attribute aren't supported with this connector\n");
+        return 0;
+    }
+
     TESTING_2("test setup")
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
@@ -1571,6 +1629,13 @@ test_open_attribute_invalid_params(void)
     hid_t  attr_type = H5I_INVALID_HID;
 
     TESTING_MULTIPART("attribute opening with invalid parameters");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_ATTR_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or attribute aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -1975,6 +2040,14 @@ test_write_attribute(void)
 
     TESTING("H5Awrite")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_ATTR_BASIC |
+                           H5VL_CAP_FLAG_FLUSH_REFRESH))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, attribute, or file flush aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file\n");
@@ -2091,6 +2164,13 @@ test_write_attribute_invalid_params(void)
     void    *data = NULL;
 
     TESTING_MULTIPART("H5Awrite with invalid parameters");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_ATTR_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or attribute aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -2253,6 +2333,13 @@ test_read_attribute(void)
 
     TESTING("H5Aread")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_ATTR_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or attribute aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -2394,6 +2481,13 @@ test_read_attribute_invalid_params(void)
     void    *read_buf = NULL;
 
     TESTING_MULTIPART("H5Aread with invalid parameters");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_ATTR_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or attribute aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -2576,6 +2670,13 @@ test_read_empty_attribute(void)
 
     TESTING("reading an empty attribute")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_ATTR_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or attribute aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -2683,6 +2784,13 @@ test_close_attribute_invalid_id(void)
 
     TESTING("H5Aclose with an invalid attribute ID")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_ATTR_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file or attribute aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -2735,6 +2843,14 @@ test_get_attribute_space_and_type(void)
     hid_t   tmp_space_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("retrieval of an attribute's dataspace and datatype");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_ATTR_BASIC |
+                           H5VL_CAP_FLAG_ATTR_MORE))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or attribute aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -3006,6 +3122,14 @@ test_get_attribute_space_and_type_invalid_params(void)
 
     TESTING_MULTIPART("H5Aget_type/H5Aget_space with invalid parameters");
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_ATTR_BASIC |
+                           H5VL_CAP_FLAG_ATTR_MORE))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or attribute aren't supported with this connector\n");
+        return 0;
+    }
+
     TESTING_2("test setup")
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
@@ -3141,6 +3265,14 @@ test_attribute_property_lists(void)
     hid_t      space_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("attribute property list operations");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_ATTR_BASIC |
+                           H5VL_CAP_FLAG_GET_PLIST))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, attribute, or getting property list aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -3399,6 +3531,14 @@ test_get_attribute_name(void)
     char    *name_buf = NULL;
 
     TESTING_MULTIPART("retrieval of an attribute's name");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_ATTR_BASIC |
+                           H5VL_CAP_FLAG_ATTR_MORE | H5VL_CAP_FLAG_CREATION_ORDER))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, attribute, or creation order aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -3808,6 +3948,14 @@ test_get_attribute_name_invalid_params(void)
 
     TESTING_MULTIPART("retrieval of an attribute's name with invalid parameters");
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_ATTR_BASIC |
+                           H5VL_CAP_FLAG_ATTR_MORE))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or attribute aren't supported with this connector\n");
+        return 0;
+    }
+
     TESTING_2("test setup")
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
@@ -4108,6 +4256,14 @@ test_get_attribute_info(void)
     hid_t      gcpl_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("retrieval of attribute info");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_ATTR_BASIC |
+                           H5VL_CAP_FLAG_ATTR_MORE | H5VL_CAP_FLAG_CREATION_ORDER))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, attribute, or creation order aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -4707,6 +4863,14 @@ test_get_attribute_info_invalid_params(void)
 
     TESTING_MULTIPART("retrieval of attribute info with invalid parameters");
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_ATTR_BASIC |
+                           H5VL_CAP_FLAG_ATTR_MORE))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or attribute aren't supported with this connector\n");
+        return 0;
+    }
+
     TESTING_2("test setup")
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
@@ -5069,6 +5233,14 @@ test_rename_attribute(void)
 
     TESTING_MULTIPART("attribute renaming");
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_ATTR_BASIC |
+                           H5VL_CAP_FLAG_ATTR_MORE))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or attribute aren't supported with this connector\n");
+        return 0;
+    }
+
     TESTING_2("test setup")
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
@@ -5265,6 +5437,14 @@ test_rename_attribute_invalid_params(void)
     hid_t  attr_space_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("attribute renaming with invalid parameters");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_ATTR_BASIC |
+                           H5VL_CAP_FLAG_ATTR_MORE))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or attribute aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -5573,6 +5753,14 @@ test_attribute_iterate_group(void)
     hid_t  gcpl_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("attribute iteration on a group");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_ATTR_BASIC |
+                           H5VL_CAP_FLAG_ITERATE | H5VL_CAP_FLAG_CREATION_ORDER))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, attribute, iterate, or creation order aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -5903,6 +6091,14 @@ test_attribute_iterate_dataset(void)
     hid_t  dcpl_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("attribute iteration on a dataset");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_ATTR_BASIC |
+                           H5VL_CAP_FLAG_DATASET_BASIC | H5VL_CAP_FLAG_ITERATE | H5VL_CAP_FLAG_CREATION_ORDER))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, dataset, attribute, iterate, or creation order aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -6252,6 +6448,14 @@ test_attribute_iterate_datatype(void)
     hid_t  tcpl_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("attribute iteration on a committed datatype");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_ATTR_BASIC |
+                           H5VL_CAP_FLAG_STORED_DATATYPES | H5VL_CAP_FLAG_ITERATE | H5VL_CAP_FLAG_CREATION_ORDER))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, stored datatype, attribute, iterate, or creation order aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -6606,6 +6810,14 @@ test_attribute_iterate_invalid_params(void)
 
     TESTING_MULTIPART("attribute iteration with invalid parameters");
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_ATTR_BASIC |
+                           H5VL_CAP_FLAG_ITERATE))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, attribute, or iterate aren't supported with this connector\n");
+        return 0;
+    }
+
     TESTING_2("test setup")
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
@@ -6948,6 +7160,14 @@ test_attribute_iterate_0_attributes(void)
 
     TESTING_MULTIPART("attribute iteration on object with 0 attributes")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_ATTR_BASIC |
+                           H5VL_CAP_FLAG_DATASET_BASIC | H5VL_CAP_FLAG_ITERATE))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, dataset, attribute, or iterate aren't supported with this connector\n");
+        return 0;
+    }
+
     TESTING_2("test setup")
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
@@ -7117,6 +7337,14 @@ test_delete_attribute(void)
     hid_t  gcpl_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("attribute deletion");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_ATTR_BASIC |
+                           H5VL_CAP_FLAG_CREATION_ORDER))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, attribute, or creation order aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -8206,6 +8434,13 @@ test_delete_attribute_invalid_params(void)
 
     TESTING_MULTIPART("attribute deletion with invalid parameters");
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_ATTR_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or attribute aren't supported with this connector\n");
+        return 0;
+    }
+
     TESTING_2("test setup")
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
@@ -8540,6 +8775,13 @@ test_attribute_exists(void)
 
     TESTING_MULTIPART("attribute existence")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_ATTR_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or attribute aren't supported with this connector\n");
+        return 0;
+    }
+
     TESTING_2("test setup")
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
@@ -8662,6 +8904,13 @@ test_attribute_exists_invalid_params(void)
     hid_t  space_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("attribute existence with invalid parameters");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_ATTR_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or attribute aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -8890,6 +9139,13 @@ test_attribute_many(void)
 
     TESTING("creating many attributes")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_ATTR_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or attribute aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file\n");
@@ -8986,6 +9242,13 @@ test_attribute_duplicate_id(void)
     hid_t  space_id = H5I_INVALID_HID;
 
     TESTING("duplicated IDs for an attribute")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_ATTR_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or attribute aren't supported with this connector\n");
+        return 0;
+    }
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -9090,6 +9353,14 @@ test_get_number_attributes(void)
     hid_t      space_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("retrieval of the number of attributes on an object")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_ATTR_BASIC |
+                           H5VL_CAP_FLAG_OBJECT_MORE))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, attribute, or object aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -9250,7 +9521,16 @@ test_attr_shared_dtype(void)
 #endif
 
     TESTING("shared datatype for attributes")
+
 #ifndef NO_SHARED_DATATYPES
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_ATTR_BASIC |
+                           H5VL_CAP_FLAG_STORED_DATATYPES | H5VL_CAP_FLAG_OBJECT_MORE))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, attribute, stored datatype, or object aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file\n");

--- a/vol_dataset_test.c
+++ b/vol_dataset_test.c
@@ -183,6 +183,13 @@ test_create_dataset_under_root(void)
 
     TESTING("dataset creation under root group")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_DATASET_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file or dataset aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -241,6 +248,13 @@ test_create_dataset_under_existing_group(void)
     hid_t fspace_id = H5I_INVALID_HID;
 
     TESTING("dataset creation under an existing group")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or dataset aren't supported with this connector\n");
+        return 0;
+    }
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -317,6 +331,13 @@ test_create_dataset_invalid_params(void)
     hid_t fspace_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("H5Dcreate with invalid parameters");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or dataset aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -528,6 +549,13 @@ test_create_anonymous_dataset(void)
 
     TESTING("anonymous dataset creation")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or dataset aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -603,6 +631,13 @@ test_create_anonymous_dataset_invalid_params(void)
     hid_t fspace_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("anonymous dataset creation with invalid parameters");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or dataset aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -764,6 +799,13 @@ test_create_dataset_null_space(void)
 
     TESTING("dataset creation with a NULL dataspace")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or dataset aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -848,6 +890,13 @@ test_create_dataset_scalar_space(void)
     hid_t fspace_id = H5I_INVALID_HID;
 
     TESTING("dataset creation with a SCALAR dataspace")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or dataset aren't supported with this connector\n");
+        return 0;
+    }
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -935,6 +984,13 @@ test_create_zero_dim_dset(void)
     int     data[1];
 
     TESTING("creation of 0-sized dataset")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or dataset aren't supported with this connector\n");
+        return 0;
+    }
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -1025,6 +1081,13 @@ test_create_dataset_random_shapes(void)
     hid_t  dset_dtype = H5I_INVALID_HID;
 
     TESTING("dataset creation with random dimension sizes")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or dataset aren't supported with this connector\n");
+        return 0;
+    }
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -1120,6 +1183,13 @@ test_create_dataset_predefined_types(void)
 
     TESTING("dataset creation with predefined datatypes")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or dataset aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -1204,6 +1274,13 @@ test_create_dataset_string_types(void)
     hid_t fspace_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("dataset creation with string types")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or dataset aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -1349,6 +1426,13 @@ test_create_dataset_compound_types(void)
     int    num_passes;
 
     TESTING("dataset creation with compound datatypes")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or dataset aren't supported with this connector\n");
+        return 0;
+    }
 
     /*
      * Make sure to pre-initialize all the compound field IDs
@@ -1511,6 +1595,13 @@ test_create_dataset_enum_types(void)
 
     TESTING("dataset creation with enum types")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or dataset aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -1644,6 +1735,13 @@ test_create_dataset_array_types(void)
     hid_t   nested_type_id = H5I_INVALID_HID;
 
     TESTING("dataset creation with array types")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or dataset aren't supported with this connector\n");
+        return 0;
+    }
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -1827,6 +1925,14 @@ test_create_dataset_creation_properties(void)
     hid_t   fspace_id = H5I_INVALID_HID, compact_fspace_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("dataset creation properties")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |
+                           H5VL_CAP_FLAG_CREATION_ORDER | H5VL_CAP_FLAG_TRACK_TIMES | H5VL_CAP_FLAG_FILTERS))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, dataset, creation order, track time, or filter pipeline aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -2410,6 +2516,13 @@ test_create_many_dataset(void)
 
     TESTING("creating many datasets")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or dataset aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -2513,6 +2626,13 @@ test_open_dataset_invalid_params(void)
     hid_t fspace_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("H5Dopen with invalid parameters");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or dataset aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -2658,6 +2778,13 @@ test_close_dataset_invalid_params(void)
 
     TESTING("H5Dclose with an invalid dataset ID")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_DATASET_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file or dataset aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -2709,6 +2836,14 @@ test_get_dataset_space_and_type(void)
     hid_t   tmp_space_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("retrieval of a dataset's dataspace and datatype");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |
+                           H5VL_CAP_FLAG_DATASET_MORE))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or dataset aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -2966,6 +3101,14 @@ test_get_dataset_space_and_type_invalid_params(void)
 
     TESTING_MULTIPART("H5Dget_type/H5Dget_space with invalid parameters");
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |
+                           H5VL_CAP_FLAG_DATASET_MORE))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or dataset aren't supported with this connector\n");
+        return 0;
+    }
+
     TESTING_2("test setup")
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
@@ -3121,6 +3264,14 @@ test_dataset_property_lists(void)
     char        vol_name[5];
 
     TESTING_MULTIPART("dataset property list operations");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |
+                           H5VL_CAP_FLAG_GET_PLIST))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, dataset, or get property list aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -3600,6 +3751,13 @@ test_read_dataset_small_all(void)
 
     TESTING("small read from dataset with H5S_ALL")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or dataset aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -3694,6 +3852,13 @@ test_read_dataset_small_hyperslab(void)
     void    *read_buf = NULL;
 
     TESTING("small read from dataset with a hyperslab selection")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or dataset aren't supported with this connector\n");
+        return 0;
+    }
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -3805,6 +3970,13 @@ test_read_dataset_small_point_selection(void)
     void    *data = NULL;
 
     TESTING("small read from dataset with a point selection")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or dataset aren't supported with this connector\n");
+        return 0;
+    }
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -3941,6 +4113,13 @@ test_dataset_io_point_selections(void)
     int i, j;
 
     TESTING("point selection I/O with all selection in memory and points in file")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or dataset aren't supported with this connector\n");
+        return 0;
+    }
 
     /* Create dataspaces and DCPL */
     if((mspace_id_full = H5Screate_simple(2, dims, NULL)) < 0)
@@ -4386,6 +4565,13 @@ test_read_dataset_large_all(void)
 
     TESTING("large read from dataset with H5S_ALL")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or dataset aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -4480,6 +4666,13 @@ test_read_dataset_large_hyperslab(void)
     void    *read_buf = NULL;
 
     TESTING("large read from dataset with a hyperslab selection")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or dataset aren't supported with this connector\n");
+        return 0;
+    }
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -4588,6 +4781,13 @@ test_read_dataset_large_point_selection(void)
     void    *data = NULL;
 
     TESTING("large read from dataset with a point selection")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or dataset aren't supported with this connector\n");
+        return 0;
+    }
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -4701,6 +4901,13 @@ test_read_dataset_invalid_params(void)
     void    *read_buf = NULL;
 
     TESTING_MULTIPART("H5Dread with invalid parameters");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or dataset aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -4892,6 +5099,14 @@ test_write_dataset_small_all(void)
 
     TESTING("small write to dataset with H5S_ALL")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |
+                           H5VL_CAP_FLAG_DATASET_MORE))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or dataset aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -5010,6 +5225,13 @@ test_write_dataset_small_hyperslab(void)
 
     TESTING("small write to dataset with a hyperslab selection")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or dataset aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -5124,6 +5346,13 @@ test_write_dataset_small_point_selection(void)
 
     TESTING("small write to dataset with a point selection")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or dataset aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -5235,6 +5464,14 @@ test_write_dataset_large_all(void)
     void     *data = NULL;
 
     TESTING("large write to dataset with H5S_ALL")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |
+                           H5VL_CAP_FLAG_DATASET_MORE))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, basic or more dataset aren't supported with this connector\n");
+        return 0;
+    }
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -5352,6 +5589,13 @@ test_write_dataset_large_hyperslab(void)
     void    *data = NULL;
 
     TESTING("large write to dataset with a hyperslab selection")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or dataset aren't supported with this connector\n");
+        return 0;
+    }
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -5488,6 +5732,14 @@ test_write_dataset_data_verification(void)
     void    *read_buf = NULL;
 
     TESTING_MULTIPART("verification of dataset data using H5Dwrite then H5Dread");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |
+                           H5VL_CAP_FLAG_DATASET_MORE))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, basic or more dataset aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -5942,6 +6194,13 @@ test_write_dataset_invalid_params(void)
 
     TESTING_MULTIPART("H5Dwrite with invalid parameters");
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or dataset aren't supported with this connector\n");
+        return 0;
+    }
+
     TESTING_2("test setup")
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
@@ -6146,6 +6405,14 @@ test_dataset_builtin_type_conversion(void)
     void    *read_buf = NULL;
 
     TESTING_MULTIPART("verification of dataset data using H5Dwrite then H5Dread with type conversion of builtin types");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |
+                           H5VL_CAP_FLAG_DATASET_MORE))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, basic or more dataset aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -6619,6 +6886,13 @@ test_dataset_compound_partial_io(void)
 
     TESTING_MULTIPART("verification of dataset data using H5Dwrite then H5Dread with partial element compound type I/O");
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or dataset aren't supported with this connector\n");
+        return 0;
+    }
+
     TESTING_2("test setup")
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
@@ -6856,6 +7130,14 @@ test_dataset_set_extent_chunked_unlimited(void)
 
     TESTING("H5Dset_extent on chunked dataset with unlimited dimensions")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |
+                           H5VL_CAP_FLAG_DATASET_MORE))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, basic or more dataset aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -7073,6 +7355,14 @@ test_dataset_set_extent_chunked_fixed(void)
     hid_t   fspace_id = H5I_INVALID_HID, fspace_id2 = H5I_INVALID_HID;
 
     TESTING("H5Dset_extent on chunked dataset with fixed dimensions")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |
+                           H5VL_CAP_FLAG_DATASET_MORE))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, basic or more dataset aren't supported with this connector\n");
+        return 0;
+    }
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -7345,6 +7635,15 @@ test_dataset_set_extent_data(void)
     int     i, j;
 
     TESTING_MULTIPART("H5Dset_extent on data correctness");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |
+                           H5VL_CAP_FLAG_DATASET_MORE))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, basic or more dataset aren't supported with this connector\n");
+        return 0;
+    }
+
     TESTING_2("test setup")
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
@@ -7655,7 +7954,17 @@ test_dataset_set_extent_double_handles(void)
 #endif
 
     TESTING("H5Dset_extent on double dataset handles")
+
 #ifndef NO_DOUBLE_OBJECT_OPENS
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |
+                           H5VL_CAP_FLAG_DATASET_MORE))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, basic or more dataset aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -7783,6 +8092,14 @@ test_dataset_set_extent_invalid_params(void)
     char   vol_name[5];
 
     TESTING_MULTIPART("H5Dset_extent with invalid parameters");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |
+                           H5VL_CAP_FLAG_DATASET_MORE))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, basic or more dataset aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -8071,6 +8388,14 @@ test_create_single_chunk_dataset(void)
 
     TESTING("creation of dataset with single chunk")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |
+                           H5VL_CAP_FLAG_GET_PLIST))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, dataset, or get property list aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -8236,6 +8561,14 @@ test_write_single_chunk_dataset(void)
     void     *read_buf = NULL;
 
     TESTING("write to dataset with single chunk")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |
+                           H5VL_CAP_FLAG_DATASET_MORE | H5VL_CAP_FLAG_GET_PLIST))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, dataset, or get property list aren't supported with this connector\n");
+        return 0;
+    }
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -8431,6 +8764,14 @@ test_create_multi_chunk_dataset(void)
 
     TESTING("creation of dataset with multiple chunks")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |
+                           H5VL_CAP_FLAG_GET_PLIST))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, dataset, or get property list aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -8601,6 +8942,14 @@ test_write_multi_chunk_dataset_same_shape_read(void)
     int      read_buf[10][10];
 
     TESTING("write to dataset with multiple chunks using same shaped dataspaces")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |
+                           H5VL_CAP_FLAG_DATASET_MORE | H5VL_CAP_FLAG_GET_PLIST))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, dataset, or get property list aren't supported with this connector\n");
+        return 0;
+    }
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -8897,6 +9246,15 @@ test_write_multi_chunk_dataset_diff_shape_read(void)
     void    *read_buf = NULL;
 
     TESTING("write to dataset with multiple chunks using differently shaped dataspaces")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |
+                           H5VL_CAP_FLAG_GET_PLIST))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, dataset, or get property list aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -9203,6 +9561,14 @@ test_overwrite_multi_chunk_dataset_same_shape_read(void)
 
     TESTING("several overwrites to dataset with multiple chunks using same shaped dataspaces")
 
+     /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |
+                           H5VL_CAP_FLAG_GET_PLIST))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, dataset, or get property list aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -9504,6 +9870,14 @@ test_overwrite_multi_chunk_dataset_diff_shape_read(void)
     void    *read_buf = NULL;
 
     TESTING("several overwrites to dataset with multiple chunks using differently shaped dataspaces")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |
+                           H5VL_CAP_FLAG_GET_PLIST))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, dataset, or get property list aren't supported with this connector\n");
+        return 0;
+    }
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -9813,6 +10187,14 @@ test_read_partial_chunk_all_selection(void)
 
     TESTING("reading a partial chunk using H5S_ALL for file dataspace")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |
+                           H5VL_CAP_FLAG_GET_PLIST))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, dataset, or get property list aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -9978,6 +10360,14 @@ test_read_partial_chunk_hyperslab_selection(void)
     hid_t   fspace_id = H5I_INVALID_HID;
 
     TESTING("reading a partial chunk using a hyperslab selection in file dataspace")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |
+                           H5VL_CAP_FLAG_GET_PLIST))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, dataset, or get property list aren't supported with this connector\n");
+        return 0;
+    }
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();

--- a/vol_datatype_test.c
+++ b/vol_datatype_test.c
@@ -86,6 +86,13 @@ test_create_committed_datatype(void)
 
     TESTING("creation of a committed datatype")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_STORED_DATATYPES))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or stored datatype aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -153,6 +160,13 @@ test_create_committed_datatype_invalid_params(void)
     hid_t  type_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("H5Tcommit2 with invalid parameters");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_STORED_DATATYPES))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or stored datatype aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -334,6 +348,13 @@ test_create_anonymous_committed_datatype(void)
 
     TESTING("creation of anonymous committed datatype")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_STORED_DATATYPES))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or stored datatype aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -401,6 +422,13 @@ test_create_anonymous_committed_datatype_invalid_params(void)
     hid_t  type_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("H5Tcommit_anon with invalid parameters");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_STORED_DATATYPES))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or stored datatype aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -536,6 +564,13 @@ test_create_committed_datatype_empty_types(void)
     hid_t  type_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("creation of committed datatype with empty types")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_STORED_DATATYPES))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or stored datatype aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -682,6 +717,13 @@ test_recommit_committed_type(void)
 
     TESTING("inability to re-commit a committed datatype")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_STORED_DATATYPES))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or stored datatype aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -773,6 +815,13 @@ test_open_committed_datatype(void)
 
     TESTING("H5Topen2")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_STORED_DATATYPES))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or stored datatype aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -848,6 +897,13 @@ test_open_committed_datatype_invalid_params(void)
     hid_t type_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("H5Topen2 with invalid parameters");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_STORED_DATATYPES))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or stored datatype aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -991,6 +1047,14 @@ test_reopen_committed_datatype_indirect(void)
     hid_t  space_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("reopening open committed datatypes using H5Dget_type")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_STORED_DATATYPES |
+                           H5VL_CAP_FLAG_DATASET_BASIC | H5VL_CAP_FLAG_DATASET_MORE))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, dataset, or stored datatype aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -1402,6 +1466,13 @@ test_close_committed_datatype_invalid_id(void)
 
     TESTING("H5Tclose with an invalid committed datatype ID")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_STORED_DATATYPES))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file or stored datatype aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -1447,6 +1518,14 @@ test_datatype_property_lists(void)
     hid_t tcpl_id1 = H5I_INVALID_HID, tcpl_id2 = H5I_INVALID_HID;
 
     TESTING_MULTIPART("datatype property list operations")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_STORED_DATATYPES |
+                           H5VL_CAP_FLAG_GET_PLIST))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, stored datatype, or getting property list aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -1634,6 +1713,14 @@ test_create_dataset_with_committed_type(void)
 
     TESTING("dataset creation with a committed datatype")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_STORED_DATATYPES |
+                           H5VL_CAP_FLAG_DATASET_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, dataset, or stored datatype aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -1764,6 +1851,14 @@ test_create_attribute_with_committed_type(void)
 
     TESTING("attribute creation with a committed datatype")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_STORED_DATATYPES |
+                           H5VL_CAP_FLAG_ATTR_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, attribute, or stored datatype aren't supported with this connector\n");
+        return 0;
+    }
+  
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -1880,6 +1975,14 @@ test_delete_committed_type(void)
 
     TESTING("committed datatype deletion")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_STORED_DATATYPES |
+                           H5VL_CAP_FLAG_LINK_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, attribute, or stored datatype aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s\n", vol_test_filename);
@@ -1982,6 +2085,14 @@ test_resurrect_datatype(void)
     TESTING("resurrecting datatype after deletion")
 
 #ifndef NO_ID_PREVENTS_OBJ_DELETE
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_STORED_DATATYPES |
+                           H5VL_CAP_FLAG_LINK_BASIC | H5VL_CAP_FLAG_HARD_LINKS))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, link, hard link, or stored datatype aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -2156,6 +2267,13 @@ test_cant_commit_predefined(void)
 
     TESTING("inability to commit predefined types directly")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_STORED_DATATYPES))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or stored datatype aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -2220,6 +2338,13 @@ test_cant_modify_committed_type(void)
     hid_t  type_id = H5I_INVALID_HID;
 
     TESTING("inability to modify a committed datatype")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_STORED_DATATYPES))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or stored datatype aren't supported with this connector\n");
+        return 0;
+    }
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();

--- a/vol_file_test.c
+++ b/vol_file_test.c
@@ -82,8 +82,16 @@ static int
 test_create_file(void)
 {
     hid_t file_id = H5I_INVALID_HID;
+    hid_t connector_id = H5I_INVALID_HID;
+    uint64_t vol_flags = 0, req_flags = H5VL_CAP_FLAG_FILE_BASIC;
 
     TESTING("H5Fcreate");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & H5VL_CAP_FLAG_FILE_BASIC)) {
+        SKIPPED();
+        return 0;
+    }
 
     if ((file_id = H5Fcreate(FILE_CREATE_TEST_FILENAME, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -116,6 +124,12 @@ test_create_file_invalid_params(void)
     hid_t file_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("H5Fcreate with invalid parameters");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & H5VL_CAP_FLAG_FILE_BASIC)) {
+        SKIPPED();
+        return 0;
+    }
 
     BEGIN_MULTIPART {
         PART_BEGIN(H5Fcreate_invalid_name) {
@@ -227,6 +241,12 @@ test_create_file_excl(void)
 
     TESTING("H5Fcreate with H5F_ACC_EXCL/H5F_ACC_TRUNC flag");
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & H5VL_CAP_FLAG_FILE_BASIC)) {
+        SKIPPED();
+        return 0;
+    }
+
     if ((file_id = H5Fcreate(FILE_CREATE_EXCL_FILE_NAME, H5F_ACC_EXCL, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't create first file\n");
@@ -282,6 +302,12 @@ test_open_file(void)
     hid_t file_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("H5Fopen");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & H5VL_CAP_FLAG_FILE_BASIC)) {
+        SKIPPED();
+        return 0;
+    }
 
     BEGIN_MULTIPART {
         PART_BEGIN(H5Fopen_rdonly) {
@@ -347,6 +373,12 @@ test_open_file_invalid_params(void)
     hid_t file_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("H5Fopen with invalid parameters");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & H5VL_CAP_FLAG_FILE_BASIC)) {
+        SKIPPED();
+        return 0;
+    }
 
     BEGIN_MULTIPART {
         PART_BEGIN(H5Fopen_invalid_name) {
@@ -427,6 +459,12 @@ test_open_nonexistent_file(void)
 
     TESTING("for invalid opening of a non-existent file")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & H5VL_CAP_FLAG_FILE_BASIC)) {
+        SKIPPED();
+        return 0;
+    }
+
     HDsnprintf(test_filename, VOL_TEST_FILENAME_MAX_LENGTH, "%s", NONEXISTENT_FILENAME);
 
     /* XXX: Make sure to first delete the file so we know for sure it doesn't exist */
@@ -467,6 +505,13 @@ test_file_permission(void)
     herr_t ret = -1;
 
     TESTING_MULTIPART("file permissions (invalid creation of objects in read-only file)");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC |
+                           H5VL_CAP_FLAG_DATASET_BASIC | H5VL_CAP_FLAG_ATTR_BASIC))) {
+        SKIPPED();
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -644,6 +689,12 @@ test_reopen_file(void)
 
     TESTING("re-open of a file with H5Freopen")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & H5VL_CAP_FLAG_FILE_BASIC)) {
+        SKIPPED();
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file\n");
@@ -684,6 +735,12 @@ test_close_file_invalid_id(void)
 
     TESTING("H5Fclose with an invalid ID")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & H5VL_CAP_FLAG_FILE_BASIC)) {
+        SKIPPED();
+        return 0;
+    }
+
     H5E_BEGIN_TRY {
         err_ret = H5Fclose(H5I_INVALID_HID);
     } H5E_END_TRY;
@@ -714,6 +771,12 @@ test_flush_file(void)
     unsigned u;
 
     TESTING_MULTIPART("H5Fflush")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_DATASET_BASIC | H5VL_CAP_FLAG_FLUSH_REFRESH))) {
+        SKIPPED();
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -803,6 +866,12 @@ test_file_is_accessible(void)
 
     TESTING_MULTIPART("H5Fis_accessible")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & H5VL_CAP_FLAG_FILE_BASIC)) {
+        SKIPPED();
+        return 0;
+    }
+
     BEGIN_MULTIPART {
         PART_BEGIN(H5Fis_accessible_valid_file) {
             TESTING_2("H5Fis_accessible on existing file")
@@ -861,6 +930,12 @@ test_file_property_lists(void)
     char    test_filename1[VOL_TEST_FILENAME_MAX_LENGTH], test_filename2[VOL_TEST_FILENAME_MAX_LENGTH];
 
     TESTING_MULTIPART("file property list operations")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_FILE_MORE))) {
+        SKIPPED();
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -1104,6 +1179,12 @@ test_get_file_intent(void)
 
     TESTING_MULTIPART("retrieval of file intent with H5Fget_intent")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_FILE_MORE))) {
+        SKIPPED();
+        return 0;
+    }
+
     TESTING_2("test setup")
 
     HDsnprintf(test_filename, VOL_TEST_FILENAME_MAX_LENGTH, "%s", FILE_INTENT_TEST_FILENAME);
@@ -1232,6 +1313,14 @@ test_get_file_obj_count(void)
     hid_t   dspace_id = H5I_INVALID_HID, dset_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("retrieval of open object number and IDs")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_FILE_MORE | H5VL_CAP_FLAG_DATASET_BASIC |
+                           H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_STORED_DATATYPES |
+                           H5VL_CAP_FLAG_ATTR_BASIC))) {
+        SKIPPED();
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -1522,6 +1611,14 @@ test_file_open_overlap(void)
 #endif
 
     TESTING("overlapping file opens")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_FILE_MORE | H5VL_CAP_FLAG_DATASET_BASIC |
+                           H5VL_CAP_FLAG_GROUP_BASIC))) {
+        SKIPPED();
+        return 0;
+    }
+
 #ifndef NO_DOUBLE_OBJECT_OPENS
     if ((file_id = H5Fcreate(OVERLAPPING_FILENAME, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -1635,6 +1732,13 @@ test_file_mounts(void)
 #endif
 
     TESTING("file mounting/unmounting")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_MOUNT | H5VL_CAP_FLAG_GROUP_BASIC))) {
+        SKIPPED();
+        return 0;
+    }
+
 #ifndef NO_FILE_MOUNTS
     if ((file_id = H5Fcreate(FILE_MOUNT_TEST_FILENAME, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -1706,6 +1810,14 @@ test_get_file_name(void)
     char    *file_name_buf = NULL;
 
     TESTING_MULTIPART("retrieval of file name")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_FILE_MORE | H5VL_CAP_FLAG_DATASET_BASIC |
+                           H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_STORED_DATATYPES |
+                           H5VL_CAP_FLAG_ATTR_BASIC))) {
+        SKIPPED();
+        return 0;
+    }
 
     TESTING_2("test setup")
 

--- a/vol_file_test.c
+++ b/vol_file_test.c
@@ -82,14 +82,13 @@ static int
 test_create_file(void)
 {
     hid_t file_id = H5I_INVALID_HID;
-    hid_t connector_id = H5I_INVALID_HID;
-    uint64_t vol_flags = 0, req_flags = H5VL_CAP_FLAG_FILE_BASIC;
 
     TESTING("H5Fcreate");
 
     /* Make sure the connector supports the API functions being tested */
     if (!(vol_cap_flags & H5VL_CAP_FLAG_FILE_BASIC)) {
         SKIPPED();
+        HDprintf("    API functions for basic file aren't supported with this connector\n");
         return 0;
     }
 
@@ -128,6 +127,7 @@ test_create_file_invalid_params(void)
     /* Make sure the connector supports the API functions being tested */
     if (!(vol_cap_flags & H5VL_CAP_FLAG_FILE_BASIC)) {
         SKIPPED();
+        HDprintf("    API functions for basic file aren't supported with this connector\n");
         return 0;
     }
 
@@ -244,6 +244,7 @@ test_create_file_excl(void)
     /* Make sure the connector supports the API functions being tested */
     if (!(vol_cap_flags & H5VL_CAP_FLAG_FILE_BASIC)) {
         SKIPPED();
+        HDprintf("    API functions for basic file aren't supported with this connector\n");
         return 0;
     }
 
@@ -306,6 +307,7 @@ test_open_file(void)
     /* Make sure the connector supports the API functions being tested */
     if (!(vol_cap_flags & H5VL_CAP_FLAG_FILE_BASIC)) {
         SKIPPED();
+        HDprintf("    API functions for basic file aren't supported with this connector\n");
         return 0;
     }
 
@@ -377,6 +379,7 @@ test_open_file_invalid_params(void)
     /* Make sure the connector supports the API functions being tested */
     if (!(vol_cap_flags & H5VL_CAP_FLAG_FILE_BASIC)) {
         SKIPPED();
+        HDprintf("    API functions for basic file aren't supported with this connector\n");
         return 0;
     }
 
@@ -462,6 +465,7 @@ test_open_nonexistent_file(void)
     /* Make sure the connector supports the API functions being tested */
     if (!(vol_cap_flags & H5VL_CAP_FLAG_FILE_BASIC)) {
         SKIPPED();
+        HDprintf("    API functions for basic file aren't supported with this connector\n");
         return 0;
     }
 
@@ -507,9 +511,10 @@ test_file_permission(void)
     TESTING_MULTIPART("file permissions (invalid creation of objects in read-only file)");
 
     /* Make sure the connector supports the API functions being tested */
-    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC |
-                           H5VL_CAP_FLAG_DATASET_BASIC | H5VL_CAP_FLAG_ATTR_BASIC))) {
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |
+                           H5VL_CAP_FLAG_ATTR_BASIC | H5VL_CAP_FLAG_STORED_DATATYPES))) {
         SKIPPED();
+        HDprintf("    API functions for basic file, group, dataset, attribute, stored datatype aren't supported with this connector\n");
         return 0;
     }
 
@@ -692,6 +697,7 @@ test_reopen_file(void)
     /* Make sure the connector supports the API functions being tested */
     if (!(vol_cap_flags & H5VL_CAP_FLAG_FILE_BASIC)) {
         SKIPPED();
+        HDprintf("    API functions for basic file aren't supported with this connector\n");
         return 0;
     }
 
@@ -738,6 +744,7 @@ test_close_file_invalid_id(void)
     /* Make sure the connector supports the API functions being tested */
     if (!(vol_cap_flags & H5VL_CAP_FLAG_FILE_BASIC)) {
         SKIPPED();
+        HDprintf("    API functions for basic file aren't supported with this connector\n");
         return 0;
     }
 
@@ -775,6 +782,7 @@ test_flush_file(void)
     /* Make sure the connector supports the API functions being tested */
     if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_DATASET_BASIC | H5VL_CAP_FLAG_FLUSH_REFRESH))) {
         SKIPPED();
+        HDprintf("    API functions for basic file, dataset, or file flush aren't supported with this connector\n");
         return 0;
     }
 
@@ -869,6 +877,7 @@ test_file_is_accessible(void)
     /* Make sure the connector supports the API functions being tested */
     if (!(vol_cap_flags & H5VL_CAP_FLAG_FILE_BASIC)) {
         SKIPPED();
+        HDprintf("    API functions for basic file aren't supported with this connector\n");
         return 0;
     }
 
@@ -932,8 +941,9 @@ test_file_property_lists(void)
     TESTING_MULTIPART("file property list operations")
 
     /* Make sure the connector supports the API functions being tested */
-    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_FILE_MORE))) {
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_FILE_MORE | H5VL_CAP_FLAG_GET_PLIST))) {
         SKIPPED();
+        HDprintf("    API functions for basic or more file or get property list aren't supported with this connector\n");
         return 0;
     }
 
@@ -1182,6 +1192,7 @@ test_get_file_intent(void)
     /* Make sure the connector supports the API functions being tested */
     if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_FILE_MORE))) {
         SKIPPED();
+        HDprintf("    API functions for basic or more file aren't supported with this connector\n");
         return 0;
     }
 
@@ -1316,9 +1327,9 @@ test_get_file_obj_count(void)
 
     /* Make sure the connector supports the API functions being tested */
     if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_FILE_MORE | H5VL_CAP_FLAG_DATASET_BASIC |
-                           H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_STORED_DATATYPES |
-                           H5VL_CAP_FLAG_ATTR_BASIC))) {
+                           H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_STORED_DATATYPES | H5VL_CAP_FLAG_ATTR_BASIC))) {
         SKIPPED();
+        HDprintf("    API functions for basic or more file,  basic dataset, group, datatype, or attribute aren't supported with this connector\n");
         return 0;
     }
 
@@ -1616,6 +1627,7 @@ test_file_open_overlap(void)
     if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_FILE_MORE | H5VL_CAP_FLAG_DATASET_BASIC |
                            H5VL_CAP_FLAG_GROUP_BASIC))) {
         SKIPPED();
+        HDprintf("    API functions for basic or more file, dataset, or group aren't supported with this connector\n");
         return 0;
     }
 
@@ -1736,6 +1748,7 @@ test_file_mounts(void)
     /* Make sure the connector supports the API functions being tested */
     if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_MOUNT | H5VL_CAP_FLAG_GROUP_BASIC))) {
         SKIPPED();
+        HDprintf("    API functions for basic file,  file mount, or basic group aren't supported with this connector\n");
         return 0;
     }
 
@@ -1813,9 +1826,9 @@ test_get_file_name(void)
 
     /* Make sure the connector supports the API functions being tested */
     if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_FILE_MORE | H5VL_CAP_FLAG_DATASET_BASIC |
-                           H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_STORED_DATATYPES |
-                           H5VL_CAP_FLAG_ATTR_BASIC))) {
+                           H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_STORED_DATATYPES | H5VL_CAP_FLAG_ATTR_BASIC))) {
         SKIPPED();
+        HDprintf("    API functions for basic or more file, basic dataset, group, datatype, or attribute aren't supported with this connector\n");
         return 0;
     }
 

--- a/vol_group_test.c
+++ b/vol_group_test.c
@@ -67,6 +67,13 @@ test_create_group_under_root(void)
 
     TESTING("creation of group under the root group")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file or group aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -110,6 +117,13 @@ test_create_group_under_existing_group(void)
           grandchild_group_id = H5I_INVALID_HID;
 
     TESTING("creation of group under existing group using a relative path")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file or group aren't supported with this connector\n");
+        return 0;
+    }
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -175,6 +189,13 @@ test_create_many_groups(void)
     unsigned i;
 
     TESTING("H5Gcreate many groups")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file or group aren't supported with this connector\n");
+        return 0;
+    }
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -242,6 +263,13 @@ test_create_deep_groups(void)
     hid_t group_id = H5I_INVALID_HID;
 
     TESTING("H5Gcreate groups of great depths")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file or group aren't supported with this connector\n");
+        return 0;
+    }
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -339,6 +367,13 @@ test_create_intermediate_group(void)
     hid_t crt_intmd_lcpl_id = H5I_INVALID_HID;
 
     TESTING("H5Gcreate group with intermediate group creation")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file or group aren't supported with this connector\n");
+        return 0;
+    }
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -454,6 +489,13 @@ test_create_group_invalid_params(void)
     hid_t group_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("H5Gcreate with invalid parameters");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file or group aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -593,6 +635,13 @@ test_create_anonymous_group(void)
 
     TESTING("creation of anonymous group")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file or group aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file\n");
@@ -643,6 +692,13 @@ test_create_anonymous_group_invalid_params(void)
     hid_t container_group = H5I_INVALID_HID, new_group_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("H5Gcreate_anon with invalid parameters");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file or group aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -746,6 +802,13 @@ test_open_nonexistent_group(void)
 
     TESTING("for invalid opening of a nonexistent group")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file or group aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file\n");
@@ -789,6 +852,13 @@ test_open_group_invalid_params(void)
     hid_t group_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("H5Gopen with invalid parameters");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file or group aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -893,6 +963,13 @@ test_close_group_invalid_id(void)
 
     TESTING("H5Gclose with an invalid group ID")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & H5VL_CAP_FLAG_GROUP_BASIC)) {
+        SKIPPED();
+        HDprintf("    API functions for basic group aren't supported with this connector\n");
+        return 0;
+    }
+
     H5E_BEGIN_TRY {
         err_ret = H5Gclose(H5I_INVALID_HID);
     } H5E_END_TRY;
@@ -926,6 +1003,14 @@ test_group_property_lists(void)
 
     TESTING_MULTIPART("group property list operations")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | 
+                           H5VL_CAP_FLAG_GET_PLIST | H5VL_CAP_FLAG_CREATION_ORDER))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, property list, creation order aren't supported with this connector\n");
+        return 0;
+    }
+ 
     TESTING_2("test setup")
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
@@ -1162,6 +1247,14 @@ test_get_group_info(void)
 
     TESTING_MULTIPART("retrieval of group info");
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC |
+                           H5VL_CAP_FLAG_GROUP_MORE | H5VL_CAP_FLAG_CREATION_ORDER))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file or group, creation order aren't supported with this connector\n");
+        return 0;
+    }
+ 
     TESTING_2("test setup")
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
@@ -1227,7 +1320,7 @@ test_get_group_info(void)
 
             if (group_info.nlinks != GROUP_GET_INFO_TEST_GROUP_NUMB) {
                 H5_FAILED();
-                HDprintf("    group's number of links '%lld' doesn't match expected value '%u'\n",
+                HDprintf("    group's number of links '%lu' doesn't match expected value '%u'\n",
                         group_info.nlinks, (unsigned int)GROUP_GET_INFO_TEST_GROUP_NUMB);
                 PART_ERROR(H5Gget_info);
             }
@@ -1277,7 +1370,7 @@ test_get_group_info(void)
 
             if (group_info.nlinks != GROUP_GET_INFO_TEST_GROUP_NUMB) {
                 H5_FAILED();
-                HDprintf("    group's number of links '%lld' doesn't match expected value '%u'\n",
+                HDprintf("    group's number of links '%lu' doesn't match expected value '%u'\n",
                         group_info.nlinks, (unsigned int)GROUP_GET_INFO_TEST_GROUP_NUMB);
                 PART_ERROR(H5Gget_info_by_name);
             }
@@ -1329,7 +1422,7 @@ test_get_group_info(void)
 
                 if (group_info.nlinks != 0) {
                     H5_FAILED();
-                    HDprintf("    group's number of links '%lld' doesn't match expected value '%d'\n",
+                    HDprintf("    group's number of links '%lu' doesn't match expected value '%d'\n",
                             group_info.nlinks, 0);
                     PART_ERROR(H5Gget_info_by_idx_crt_order_increasing);
                 }
@@ -1378,7 +1471,7 @@ test_get_group_info(void)
 
                 if (group_info.nlinks != 0) {
                     H5_FAILED();
-                    HDprintf("    group's number of links '%lld' doesn't match expected value '%d'\n",
+                    HDprintf("    group's number of links '%lu' doesn't match expected value '%d'\n",
                             group_info.nlinks, 0);
                     PART_ERROR(H5Gget_info_by_idx_crt_order_decreasing);
                 }
@@ -1427,7 +1520,7 @@ test_get_group_info(void)
 
                 if (group_info.nlinks != 0) {
                     H5_FAILED();
-                    HDprintf("    group's number of links '%lld' doesn't match expected value '%d'\n",
+                    HDprintf("    group's number of links '%lu' doesn't match expected value '%d'\n",
                             group_info.nlinks, 0);
                     PART_ERROR(H5Gget_info_by_idx_name_order_increasing);
                 }
@@ -1553,6 +1646,13 @@ test_get_group_info_invalid_params(void)
     hid_t      file_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("retrieval of group info with invalid parameters");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_MORE | H5VL_CAP_FLAG_CREATION_ORDER))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, more group, creation order aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -1827,6 +1927,13 @@ test_flush_group(void)
 
     TESTING("H5Gflush")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_FLUSH_REFRESH))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, more group, creation order aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -1884,6 +1991,13 @@ test_flush_group_invalid_params(void)
 
     TESTING("H5Gflush with invalid parameters")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & H5VL_CAP_FLAG_FLUSH_REFRESH)) {
+        SKIPPED();
+        HDprintf("    API functions for group flush aren't supported with this connector\n");
+        return 0;
+    }
+
     H5E_BEGIN_TRY {
         status = H5Gflush(H5I_INVALID_HID);
     } H5E_END_TRY;
@@ -1913,6 +2027,13 @@ test_refresh_group(void)
     hid_t group_id = H5I_INVALID_HID;
 
     TESTING("H5Grefresh")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_FLUSH_REFRESH))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or refresh aren't supported with this connector\n");
+        return 0;
+    }
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -1971,6 +2092,13 @@ test_refresh_group_invalid_params(void)
 
     TESTING("H5Grefresh with invalid parameters")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & H5VL_CAP_FLAG_FLUSH_REFRESH)) {
+        SKIPPED();
+        HDprintf("    API functions for group refresh aren't supported with this connector\n");
+        return 0;
+    }
+
     H5E_BEGIN_TRY {
         status = H5Grefresh(H5I_INVALID_HID);
     } H5E_END_TRY;
@@ -2008,4 +2136,4 @@ vol_group_test(void)
     HDprintf("\n");
 
     return nerrors;
-}
+} 

--- a/vol_link_test.c
+++ b/vol_link_test.c
@@ -190,6 +190,13 @@ test_create_hard_link(void)
 
     TESTING("hard link creation")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_LINK_BASIC | H5VL_CAP_FLAG_HARD_LINKS))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file or group, basic or hard link aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -264,6 +271,13 @@ test_create_hard_link_long_name(void)
     size_t u;               /* Local index variable */
 
     TESTING("hard link creation with a long name")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_LINK_BASIC | H5VL_CAP_FLAG_HARD_LINKS))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file or group, basic or hard link aren't supported with this connector\n");
+        return 0;
+    }
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -364,6 +378,13 @@ test_create_hard_link_many(void)
 #endif
 
     TESTING("hard link creation of many links")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_HARD_LINKS))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file or group, or hard link aren't supported with this connector\n");
+        return 0;
+    }
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -510,6 +531,13 @@ test_create_hard_link_same_loc(void)
 
     TESTING_MULTIPART("hard link creation with H5L_SAME_LOC")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_LINK_BASIC | H5VL_CAP_FLAG_HARD_LINKS))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file or group, basic or hard link aren't supported with this connector\n");
+        return 0;
+    }
+
     TESTING_2("test setup")
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
@@ -628,6 +656,13 @@ test_create_hard_link_invalid_params(void)
     hid_t  ext_file_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("hard link creation with invalid parameters");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_LINK_BASIC | H5VL_CAP_FLAG_HARD_LINKS))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file or group, basic or hard link aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -883,6 +918,13 @@ test_create_soft_link_existing_relative(void)
 
     TESTING("soft link creation to existing object by relative path")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_LINK_BASIC | H5VL_CAP_FLAG_SOFT_LINKS))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file or group, basic or soft link aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -975,6 +1017,13 @@ test_create_soft_link_existing_absolute(void)
 
     TESTING("soft link creation to existing object by absolute path")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_LINK_BASIC | H5VL_CAP_FLAG_SOFT_LINKS))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file or group, basic or soft link aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -1056,6 +1105,13 @@ test_create_soft_link_dangling_relative(void)
     hid_t  object_id = H5I_INVALID_HID;
 
     TESTING("dangling soft link creation to object by relative path")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_LINK_BASIC | H5VL_CAP_FLAG_SOFT_LINKS))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file or group, basic or soft link aren't supported with this connector\n");
+        return 0;
+    }
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -1160,6 +1216,13 @@ test_create_soft_link_dangling_absolute(void)
     hid_t  object_id = H5I_INVALID_HID;
 
     TESTING("dangling soft link creation to object by absolute path")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_LINK_BASIC | H5VL_CAP_FLAG_SOFT_LINKS))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file or group, basic or soft link aren't supported with this connector\n");
+        return 0;
+    }
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -1267,6 +1330,13 @@ test_create_soft_link_long_name(void)
 
     TESTING("soft link creation with a long name")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_LINK_BASIC | H5VL_CAP_FLAG_SOFT_LINKS))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file or group, basic or soft link aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -1369,6 +1439,14 @@ test_create_soft_link_many(void)
 #endif
 
     TESTING("soft link creation of many links")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_LINK_BASIC | H5VL_CAP_FLAG_SOFT_LINKS))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file or group, basic or soft link aren't supported with this connector\n");
+        return 0;
+    }
+
 #ifndef NO_SOFT_LINK_MANY_DANGLING
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -1533,6 +1611,13 @@ test_create_soft_link_invalid_params(void)
     hid_t  container_group = H5I_INVALID_HID, group_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("soft link creation with invalid parameters");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_SOFT_LINKS))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or link aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -1720,6 +1805,14 @@ test_create_external_link(void)
 #endif
 
     TESTING("external link creation to existing object")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_LINK_BASIC | H5VL_CAP_FLAG_EXTERNAL_LINKS))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, basic link, or external link aren't supported with this connector\n");
+        return 0;
+    }
+
 #ifndef NO_EXTERNAL_LINKS
     HDsnprintf(ext_link_filename, VOL_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
@@ -1821,6 +1914,14 @@ test_create_external_link_dangling(void)
 #endif
 
     TESTING("dangling external link creation")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_LINK_BASIC | H5VL_CAP_FLAG_EXTERNAL_LINKS))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, basic link, or external link aren't supported with this connector\n");
+        return 0;
+    }
+
 #ifndef NO_EXTERNAL_LINKS
     HDsnprintf(ext_link_filename, VOL_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
@@ -1946,6 +2047,14 @@ test_create_external_link_multi(void)
 #endif
 
     TESTING_MULTIPART("external link creation to an object across several files")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_EXTERNAL_LINKS))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or external link aren't supported with this connector\n");
+        return 0;
+    }
+
 #ifndef NO_EXTERNAL_LINKS
     BEGIN_MULTIPART {
         PART_BEGIN(H5Lcreate_external_first_file) {
@@ -2285,6 +2394,14 @@ test_create_external_link_ping_pong(void)
 #endif
 
     TESTING_MULTIPART("external link creation to an object in ping pong style")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_EXTERNAL_LINKS))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or external link aren't supported with this connector\n");
+        return 0;
+    }
+
 #ifndef NO_EXTERNAL_LINKS
     HDsnprintf(ext_link_filename1, VOL_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_PING_PONG_NAME1);
     HDsnprintf(ext_link_filename2, VOL_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_PING_PONG_NAME2);
@@ -2516,6 +2633,13 @@ test_create_external_link_invalid_params(void)
 
     TESTING_MULTIPART("H5Lcreate_external with invalid parameters");
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_LINK_BASIC | H5VL_CAP_FLAG_EXTERNAL_LINKS))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or basic link or external link aren't supported with this connector\n");
+        return 0;
+    }
+
     TESTING_2("test setup")
 
     HDsnprintf(ext_link_filename, VOL_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_INVALID_PARAMS_TEST_FILE_NAME);
@@ -2734,6 +2858,14 @@ test_create_user_defined_link(void)
 #endif
 
     TESTING("user-defined link creation")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_LINK_BASIC | H5VL_CAP_FLAG_UD_LINKS))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or user-defined link aren't supported with this connector\n");
+        return 0;
+    }
+
 #ifndef NO_USER_DEFINED_LINKS
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -2816,6 +2948,13 @@ test_create_user_defined_link_invalid_params(void)
     char    udata[UD_LINK_INVALID_PARAMS_TEST_UDATA_MAX_SIZE];
 
     TESTING_MULTIPART("H5Lcreate_ud with invalid parameters");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_UD_LINKS))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or link aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -3017,6 +3156,15 @@ test_delete_link(void)
 #endif
 
     TESTING_MULTIPART("link deletion");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_LINK_BASIC |
+                           H5VL_CAP_FLAG_LINK_MORE | H5VL_CAP_FLAG_HARD_LINKS | H5VL_CAP_FLAG_EXTERNAL_LINKS |
+                           H5VL_CAP_FLAG_SOFT_LINKS | H5VL_CAP_FLAG_CREATION_ORDER))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or link, hard, soft, or external link aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -6083,6 +6231,15 @@ test_delete_link_reset_grp_max_crt_order(void)
 #endif
 
     TESTING_MULTIPART("H5Ldelete of all links in group resets group's maximum link creation order value")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_GROUP_MORE | H5VL_CAP_FLAG_LINK_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, basic and more group, or basic link aren't supported with this connector\n");
+        return 0;
+    }
+
+
 #ifndef NO_MAX_LINK_CRT_ORDER_RESET
     TESTING_2("test setup")
 
@@ -6301,6 +6458,14 @@ test_delete_link_invalid_params(void)
     hid_t  container_group = H5I_INVALID_HID, group_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("H5Ldelete with invalid parameters");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_LINK_BASIC |
+                           H5VL_CAP_FLAG_BY_IDX | H5VL_CAP_FLAG_HARD_LINKS))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or link aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -6578,6 +6743,15 @@ test_copy_link(void)
 #endif
 
     TESTING_MULTIPART("link copying")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_LINK_BASIC |
+                           H5VL_CAP_FLAG_LINK_MORE | H5VL_CAP_FLAG_HARD_LINKS | H5VL_CAP_FLAG_EXTERNAL_LINKS |
+                           H5VL_CAP_FLAG_SOFT_LINKS))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or link, hard, soft, or external link aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -7764,6 +7938,14 @@ test_copy_link_invalid_params(void)
 
     TESTING_MULTIPART("H5Lcopy with invalid parameters");
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_LINK_BASIC |
+                           H5VL_CAP_FLAG_LINK_MORE | H5VL_CAP_FLAG_HARD_LINKS))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or basic and more link aren't supported with this connector\n");
+        return 0;
+    }
+
     TESTING_2("test setup")
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
@@ -8039,6 +8221,15 @@ test_move_link(void)
     hid_t  ext_file_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("link moving")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_LINK_BASIC |
+                           H5VL_CAP_FLAG_LINK_MORE | H5VL_CAP_FLAG_HARD_LINKS | H5VL_CAP_FLAG_EXTERNAL_LINKS |
+                           H5VL_CAP_FLAG_SOFT_LINKS))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or link, hard, soft, or external link aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -9458,6 +9649,14 @@ test_move_links_into_group_with_links(void)
 
     TESTING("H5Lmove adjusting creation order values for moved links")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_LINK_MORE |
+                           H5VL_CAP_FLAG_HARD_LINKS | H5VL_CAP_FLAG_CREATION_ORDER))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or basic or hard link, or creation order aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -9647,6 +9846,15 @@ test_move_link_reset_grp_max_crt_order(void)
 #endif
 
     TESTING("H5Lmove of all links out of group resets group's maximum link creation order value")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_GROUP_MORE |
+                           H5VL_CAP_FLAG_LINK_MORE | H5VL_CAP_FLAG_HARD_LINKS | H5VL_CAP_FLAG_CREATION_ORDER))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, more or hard link, or creation order aren't supported with this connector\n");
+        return 0;
+    }
+
 #ifndef NO_MAX_LINK_CRT_ORDER_RESET
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -9818,6 +10026,14 @@ test_move_link_invalid_params(void)
     hid_t  ext_file_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("H5Lmove with invalid parameters");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_LINK_MORE |
+                           H5VL_CAP_FLAG_HARD_LINKS))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, more or hard link aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -10162,6 +10378,15 @@ test_get_link_val(void)
 #endif
 
     TESTING_MULTIPART("link value retrieval");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC |
+                           H5VL_CAP_FLAG_LINK_BASIC | H5VL_CAP_FLAG_LINK_MORE | H5VL_CAP_FLAG_SOFT_LINKS |
+                           H5VL_CAP_FLAG_EXTERNAL_LINKS | H5VL_CAP_FLAG_CREATION_ORDER))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, basic, more, soft, external link, or creation order aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -12165,6 +12390,15 @@ test_get_link_val_invalid_params(void)
 
     TESTING_MULTIPART("link value retrieval with invalid parameters");
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC |
+                           H5VL_CAP_FLAG_LINK_BASIC | H5VL_CAP_FLAG_LINK_MORE | H5VL_CAP_FLAG_SOFT_LINKS |
+                           H5VL_CAP_FLAG_CREATION_ORDER))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, basic, more, soft, external link, or creation order aren't supported with this connector\n");
+        return 0;
+    }
+
     TESTING_2("test setup")
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
@@ -12466,6 +12700,15 @@ test_get_link_info(void)
 #endif
 
     TESTING_MULTIPART("link info retrieval");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC |
+                           H5VL_CAP_FLAG_LINK_BASIC | H5VL_CAP_FLAG_LINK_MORE | H5VL_CAP_FLAG_SOFT_LINKS |
+                           H5VL_CAP_FLAG_HARD_LINKS | H5VL_CAP_FLAG_EXTERNAL_LINKS | H5VL_CAP_FLAG_CREATION_ORDER))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, basic, more, soft, hard, external link, or creation order aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -14835,6 +15078,15 @@ test_get_link_info_invalid_params(void)
 
     TESTING_MULTIPART("link info retrieval with invalid parameters");
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC |
+                           H5VL_CAP_FLAG_LINK_BASIC | H5VL_CAP_FLAG_LINK_MORE |
+                           H5VL_CAP_FLAG_HARD_LINKS | H5VL_CAP_FLAG_CREATION_ORDER))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, basic, more, soft, hard, external link, or creation order aren't supported with this connector\n");
+        return 0;
+    }
+
     TESTING_2("test setup")
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
@@ -15108,6 +15360,16 @@ test_get_link_name(void)
 
     TESTING_MULTIPART("link name retrieval")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC |
+                           H5VL_CAP_FLAG_LINK_BASIC | H5VL_CAP_FLAG_LINK_MORE |
+                           H5VL_CAP_FLAG_HARD_LINKS | H5VL_CAP_FLAG_SOFT_LINKS |
+                           H5VL_CAP_FLAG_EXTERNAL_LINKS | H5VL_CAP_FLAG_CREATION_ORDER))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, basic, more, soft, hard, external link, or creation order aren't supported with this connector\n");
+        return 0;
+    }
+ 
     TESTING_2("test setup")
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
@@ -17081,6 +17343,16 @@ test_get_link_name_invalid_params(void)
 
     TESTING_MULTIPART("link name retrieval with invalid parameters");
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC |
+                           H5VL_CAP_FLAG_LINK_BASIC | H5VL_CAP_FLAG_LINK_MORE |
+                           H5VL_CAP_FLAG_HARD_LINKS | H5VL_CAP_FLAG_SOFT_LINKS |
+                           H5VL_CAP_FLAG_EXTERNAL_LINKS | H5VL_CAP_FLAG_CREATION_ORDER))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, basic, more, soft, hard, external link, or creation order aren't supported with this connector\n");
+        return 0;
+    }
+
     TESTING_2("test setup")
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
@@ -17293,6 +17565,14 @@ test_link_iterate_hard_links(void)
     hid_t  dset_dspace = H5I_INVALID_HID;
 
     TESTING_MULTIPART("link iteration (only hard links)")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |
+                           H5VL_CAP_FLAG_ITERATE | H5VL_CAP_FLAG_LINK_BASIC | H5VL_CAP_FLAG_CREATION_ORDER))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, dataset, link, or iterate aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -17608,6 +17888,14 @@ test_link_iterate_soft_links(void)
 
     TESTING_MULTIPART("link iteration (only soft links)")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_SOFT_LINKS |
+                           H5VL_CAP_FLAG_ITERATE | H5VL_CAP_FLAG_LINK_BASIC | H5VL_CAP_FLAG_CREATION_ORDER))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, link, or iterate aren't supported with this connector\n");
+        return 0;
+    }
+
     TESTING_2("test setup")
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
@@ -17907,6 +18195,15 @@ test_link_iterate_external_links(void)
 #endif
 
     TESTING_MULTIPART("link iteration (only external links)")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_EXTERNAL_LINKS | 
+                           H5VL_CAP_FLAG_ITERATE | H5VL_CAP_FLAG_LINK_BASIC | H5VL_CAP_FLAG_CREATION_ORDER))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, link, or iterate aren't supported with this connector\n");
+        return 0;
+    }
+
 #ifndef NO_EXTERNAL_LINKS
     TESTING_2("test setup")
 
@@ -18251,6 +18548,16 @@ test_link_iterate_mixed_links(void)
 #endif
 
     TESTING_MULTIPART("link iteration (mixed link types)")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_EXTERNAL_LINKS |
+                           H5VL_CAP_FLAG_SOFT_LINKS | H5VL_CAP_FLAG_ITERATE | H5VL_CAP_FLAG_LINK_BASIC |
+                           H5VL_CAP_FLAG_CREATION_ORDER))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, link, soft or external link, iterate, or creation order aren't supported with this connector\n");
+        return 0;
+    }
+
 #if !defined(NO_EXTERNAL_LINKS) && !defined(NO_USER_DEFINED_LINKS)
     TESTING_2("test setup")
 
@@ -18662,6 +18969,15 @@ test_link_iterate_invalid_params(void)
 
     TESTING_MULTIPART("link iteration with invalid parameters");
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |
+                           H5VL_CAP_FLAG_EXTERNAL_LINKS | H5VL_CAP_FLAG_SOFT_LINKS | H5VL_CAP_FLAG_ITERATE |
+                           H5VL_CAP_FLAG_LINK_BASIC | H5VL_CAP_FLAG_CREATION_ORDER))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, dataset, link, soft or external link, iterate, or creation order aren't supported with this connector\n");
+        return 0;
+    }
+
     TESTING_2("test setup")
 
     HDsnprintf(ext_link_filename, VOL_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
@@ -19007,6 +19323,14 @@ test_link_iterate_0_links(void)
 
     TESTING_MULTIPART("link iteration on group with 0 links");
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_ITERATE |
+                           H5VL_CAP_FLAG_CREATION_ORDER))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, link iterate, or creation order aren't supported with this connector\n");
+        return 0;
+    }
+
     TESTING_2("test setup")
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
@@ -19200,6 +19524,14 @@ test_link_visit_hard_links_no_cycles(void)
     hid_t  dset_dspace = H5I_INVALID_HID;
 
     TESTING_MULTIPART("link visiting without cycles (only hard links)")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |
+                           H5VL_CAP_FLAG_ITERATE | H5VL_CAP_FLAG_CREATION_ORDER))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, link iterate, or creation order aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -19541,6 +19873,14 @@ test_link_visit_soft_links_no_cycles(void)
 
     TESTING_MULTIPART("link visiting without cycles (only soft links)")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_LINK_BASIC |
+                           H5VL_CAP_FLAG_SOFT_LINKS | H5VL_CAP_FLAG_ITERATE | H5VL_CAP_FLAG_CREATION_ORDER))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, link, soft link, iterate, or creation order aren't supported with this connector\n");
+        return 0;
+    }
+
     TESTING_2("test setup")
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
@@ -19864,6 +20204,15 @@ test_link_visit_external_links_no_cycles(void)
 #endif
 
     TESTING_MULTIPART("link visiting without cycles (only external links)")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_LINK_BASIC |
+                           H5VL_CAP_FLAG_EXTERNAL_LINKS | H5VL_CAP_FLAG_ITERATE | H5VL_CAP_FLAG_CREATION_ORDER))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, link, external link, iterate, or creation order aren't supported with this connector\n");
+        return 0;
+    }
+
 #ifndef NO_EXTERNAL_LINKS
     TESTING_2("test setup")
 
@@ -20232,6 +20581,16 @@ test_link_visit_mixed_links_no_cycles(void)
 #endif
 
     TESTING_MULTIPART("link visiting without cycles (mixed link types)")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_LINK_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |
+                           H5VL_CAP_FLAG_HARD_LINKS | H5VL_CAP_FLAG_SOFT_LINKS | H5VL_CAP_FLAG_EXTERNAL_LINKS |
+                           H5VL_CAP_FLAG_ITERATE | H5VL_CAP_FLAG_CREATION_ORDER))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, link, hard, soft, external link, iterate, or creation order aren't supported with this connector\n");
+        return 0;
+    }
+
 #if !defined(NO_EXTERNAL_LINKS) && !defined(NO_USER_DEFINED_LINKS)
     TESTING_2("test setup")
 
@@ -20641,6 +21000,14 @@ test_link_visit_hard_links_cycles(void)
 
     TESTING_MULTIPART("link visiting with cycles (only hard links)")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_LINK_BASIC |
+                           H5VL_CAP_FLAG_HARD_LINKS | H5VL_CAP_FLAG_ITERATE | H5VL_CAP_FLAG_CREATION_ORDER))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, link, hard link, iterate, or creation order aren't supported with this connector\n");
+        return 0;
+    }
+
     TESTING_2("test setup")
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
@@ -20958,6 +21325,14 @@ test_link_visit_soft_links_cycles(void)
     hid_t  gcpl_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("link visiting with cycles (only soft links)")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_LINK_BASIC |
+                           H5VL_CAP_FLAG_SOFT_LINKS | H5VL_CAP_FLAG_ITERATE | H5VL_CAP_FLAG_CREATION_ORDER))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, link, soft link, iterate, or creation order aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -21284,6 +21659,15 @@ test_link_visit_external_links_cycles(void)
 #endif
 
     TESTING_MULTIPART("link visiting with cycles (only external links)")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_LINK_BASIC |
+                           H5VL_CAP_FLAG_EXTERNAL_LINKS | H5VL_CAP_FLAG_ITERATE | H5VL_CAP_FLAG_CREATION_ORDER))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, link, external link, iterate, or creation order aren't supported with this connector\n");
+        return 0;
+    }
+
 #ifndef NO_EXTERNAL_LINKS
     TESTING_2("test setup")
 
@@ -21639,6 +22023,16 @@ test_link_visit_mixed_links_cycles(void)
 #endif
 
     TESTING_MULTIPART("link visiting with cycles (mixed link types)")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_LINK_BASIC |
+                           H5VL_CAP_FLAG_HARD_LINKS | H5VL_CAP_FLAG_SOFT_LINKS | H5VL_CAP_FLAG_EXTERNAL_LINKS |
+                           H5VL_CAP_FLAG_ITERATE | H5VL_CAP_FLAG_CREATION_ORDER))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, link, hard, soft, external link, iterate, or creation order aren't supported with this connector\n");
+        return 0;
+    }
+
 #if !defined(NO_EXTERNAL_LINKS) && !defined(NO_USER_DEFINED_LINKS)
     TESTING_2("test setup")
 
@@ -22017,6 +22411,15 @@ test_link_visit_invalid_params(void)
     char   ext_link_filename[VOL_TEST_FILENAME_MAX_LENGTH];
 
     TESTING_MULTIPART("link visiting with invalid parameters");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_LINK_BASIC |
+                           H5VL_CAP_FLAG_DATASET_BASIC | H5VL_CAP_FLAG_EXTERNAL_LINKS | H5VL_CAP_FLAG_ITERATE |
+                           H5VL_CAP_FLAG_CREATION_ORDER))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, dataset, link, external link, iterate, or creation order aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -22397,6 +22800,14 @@ test_link_visit_0_links(void)
     hid_t gcpl_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("link visiting on group with subgroups containing 0 links");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC |
+                           H5VL_CAP_FLAG_ITERATE | H5VL_CAP_FLAG_CREATION_ORDER))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, link iterate, or creation order aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 

--- a/vol_misc_test.c
+++ b/vol_misc_test.c
@@ -43,6 +43,13 @@ test_open_link_without_leading_slash(void)
 
     TESTING("opening a link without a leading slash")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or dataset aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file\n");
@@ -132,6 +139,14 @@ test_object_creation_by_absolute_path(void)
     hid_t  dset_dtype = H5I_INVALID_HID;
 
     TESTING_MULTIPART("object creation by absolute path")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |
+                           H5VL_CAP_FLAG_LINK_BASIC | H5VL_CAP_FLAG_STORED_DATATYPES))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, dataset, link, or stored datatype aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -316,6 +331,14 @@ test_absolute_vs_relative_path(void)
     hid_t  fspace_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("absolute vs. relative pathnames")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |
+                           H5VL_CAP_FLAG_LINK_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, dataset, or link aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -595,6 +618,14 @@ test_dot_for_object_name(void)
 
     TESTING_MULTIPART("creating objects with \".\" as the name");
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |
+                           H5VL_CAP_FLAG_STORED_DATATYPES))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, dataset, or stored datatype aren't supported with this connector\n");
+        return 0;
+    }
+
     TESTING_2("test setup")
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
@@ -757,6 +788,13 @@ test_symbols_in_compound_field_name(void)
     char   member_names[COMPOUND_WITH_SYMBOLS_IN_MEMBER_NAMES_TEST_NUM_SUBTYPES][256];
 
     TESTING("usage of '{', '}' and '\\\"' symbols in compound field name")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or dataset aren't supported with this connector\n");
+        return 0;
+    }
 
     for (i = 0; i < COMPOUND_WITH_SYMBOLS_IN_MEMBER_NAMES_TEST_NUM_SUBTYPES; i++)
         type_pool[i] = H5I_INVALID_HID;

--- a/vol_object_test.c
+++ b/vol_object_test.c
@@ -113,6 +113,14 @@ test_open_object(void)
 
     TESTING_2("test setup")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_OBJECT_BASIC |
+                           H5VL_CAP_FLAG_DATASET_BASIC | H5VL_CAP_FLAG_STORED_DATATYPES))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, object, dataset, or stored datatype aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -376,6 +384,13 @@ test_open_object_invalid_params(void)
     hid_t gcpl_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("object opening with invalid parameters");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_OBJECT_BASIC | H5VL_CAP_FLAG_CREATION_ORDER))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, object, or creation order aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -688,6 +703,14 @@ test_object_exists(void)
 
     TESTING_MULTIPART("object existence");
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_OBJECT_BASIC |
+                           H5VL_CAP_FLAG_DATASET_BASIC | H5VL_CAP_FLAG_STORED_DATATYPES | H5VL_CAP_FLAG_SOFT_LINKS))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, object, dataset, stored datatype or soft link aren't supported with this connector\n");
+        return 0;
+    }
+
     TESTING_2("test setup")
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
@@ -918,6 +941,13 @@ test_object_exists_invalid_params(void)
 
     TESTING_MULTIPART("object existence with invalid parameters");
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_OBJECT_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or object aren't supported with this connector\n");
+        return 0;
+    }
+
     TESTING_2("test setup")
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
@@ -1079,6 +1109,14 @@ test_link_object(void)
 
     TESTING_MULTIPART("object linking");
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_OBJECT_BASIC |
+                           H5VL_CAP_FLAG_DATASET_BASIC | H5VL_CAP_FLAG_STORED_DATATYPES))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, object, dataset, or stored datatype aren't supported with this connector\n");
+        return 0;
+    }
+
     TESTING_2("test setup")
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
@@ -1214,6 +1252,13 @@ test_link_object_invalid_params(void)
     herr_t status;
 
     TESTING_MULTIPART("object linking with invalid parameters");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_OBJECT_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or object aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -1382,6 +1427,14 @@ test_incr_decr_object_refcount(void)
     hid_t      dset_dtype = H5I_INVALID_HID;
 
     TESTING_MULTIPART("increment/decrement the reference count of object");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_OBJECT_BASIC |
+                           H5VL_CAP_FLAG_OBJECT_MORE | H5VL_CAP_FLAG_DATASET_BASIC | H5VL_CAP_FLAG_STORED_DATATYPES))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, dataset, stored datatype, basic or more object  aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -1631,6 +1684,13 @@ test_incr_decr_object_refcount_invalid_params(void)
 
     TESTING_MULTIPART("object reference count incr./decr. with an invalid parameter");
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & H5VL_CAP_FLAG_OBJECT_MORE)) {
+        SKIPPED();
+        HDprintf("    API functions for more object aren't supported with this connector\n");
+        return 0;
+    }
+
     BEGIN_MULTIPART {
         PART_BEGIN(H5Oincr_refcount_invalid_param) {
             TESTING_2("H5Oincr_refcount with invalid object ID")
@@ -1696,6 +1756,15 @@ test_object_copy_basic(void)
     hid_t       space_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("basic object copying")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_OBJECT_BASIC |
+                           H5VL_CAP_FLAG_OBJECT_MORE | H5VL_CAP_FLAG_LINK_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |
+                           H5VL_CAP_FLAG_STORED_DATATYPES | H5VL_CAP_FLAG_ATTR_BASIC | H5VL_CAP_FLAG_ITERATE))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, object, link, dataset, attribute, iterate, or stored datatype aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -2208,6 +2277,14 @@ test_object_copy_already_existing(void)
 
     TESTING_MULTIPART("object copying to location where objects already exist")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_OBJECT_BASIC |
+                           H5VL_CAP_FLAG_OBJECT_MORE | H5VL_CAP_FLAG_DATASET_BASIC | H5VL_CAP_FLAG_STORED_DATATYPES))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, object, dataset, or stored datatype aren't supported with this connector\n");
+        return 0;
+    }
+
     TESTING_2("test setup")
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
@@ -2375,6 +2452,14 @@ test_object_copy_shallow_group_copy(void)
     hid_t      ocpypl_id = H5I_INVALID_HID;
 
     TESTING("object copying with H5O_COPY_SHALLOW_HIERARCHY_FLAG flag")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_OBJECT_BASIC |
+                          H5VL_CAP_FLAG_LINK_BASIC | H5VL_CAP_FLAG_GROUP_MORE))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, object, or link aren't supported with this connector\n");
+        return 0;
+    }
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -2590,6 +2675,15 @@ test_object_copy_no_attributes(void)
     hid_t       ocpypl_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("object copying with H5O_COPY_WITHOUT_ATTR_FLAG flag")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_OBJECT_BASIC |
+                           H5VL_CAP_FLAG_OBJECT_MORE | H5VL_CAP_FLAG_LINK_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |
+                           H5VL_CAP_FLAG_ATTR_BASIC | H5VL_CAP_FLAG_STORED_DATATYPES))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, object, link, dataset, attribute, or stored datatype aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -3043,6 +3137,15 @@ test_object_copy_by_soft_link(void)
 
     TESTING_MULTIPART("object copying through use of soft links")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_OBJECT_BASIC |
+                           H5VL_CAP_FLAG_OBJECT_MORE | H5VL_CAP_FLAG_LINK_BASIC | H5VL_CAP_FLAG_LINK_MORE |
+                           H5VL_CAP_FLAG_ATTR_BASIC | H5VL_CAP_FLAG_ITERATE | H5VL_CAP_FLAG_SOFT_LINKS))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, object, link, dataset, attribute, iterate, or soft link aren't supported with this connector\n");
+        return 0;
+    }
+
     TESTING_2("test setup")
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
@@ -3325,6 +3428,15 @@ test_object_copy_group_with_soft_links(void)
     hid_t      ocpypl_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("group copying when group contains soft links")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_OBJECT_BASIC |
+                           H5VL_CAP_FLAG_OBJECT_MORE | H5VL_CAP_FLAG_LINK_BASIC | H5VL_CAP_FLAG_LINK_MORE |
+                           H5VL_CAP_FLAG_ITERATE | H5VL_CAP_FLAG_SOFT_LINKS))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, object, link, or soft link aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -3641,6 +3753,16 @@ test_object_copy_between_files(void)
     hid_t      ocpypl_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("object copying between files")
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_OBJECT_BASIC |
+                           H5VL_CAP_FLAG_OBJECT_MORE | H5VL_CAP_FLAG_LINK_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |
+                           H5VL_CAP_FLAG_ATTR_BASIC | H5VL_CAP_FLAG_STORED_DATATYPES | H5VL_CAP_FLAG_LINK_MORE |
+                           H5VL_CAP_FLAG_GROUP_MORE))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, object, link, dataset, attribute, stored datatype, or iterate aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -4161,6 +4283,13 @@ test_object_copy_invalid_params(void)
 
     TESTING_MULTIPART("object copying with invalid parameters");
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_OBJECT_MORE))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or object aren't supported with this connector\n");
+        return 0;
+    }
+
     TESTING_2("test setup")
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
@@ -4389,6 +4518,15 @@ test_object_visit(void)
     hid_t  fspace_id = H5I_INVALID_HID;
 
     TESTING_MULTIPART("object visiting");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_OBJECT_BASIC |
+                           H5VL_CAP_FLAG_DATASET_BASIC | H5VL_CAP_FLAG_ATTR_BASIC | H5VL_CAP_FLAG_STORED_DATATYPES |
+                           H5VL_CAP_FLAG_ITERATE | H5VL_CAP_FLAG_CREATION_ORDER))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, object, dataset, attribute, stored datatype, iterate, or creation order aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 
@@ -4852,6 +4990,14 @@ test_object_visit_soft_link(void)
 
     TESTING_MULTIPART("object visiting with soft links");
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_OBJECT_BASIC |
+                           H5VL_CAP_FLAG_SOFT_LINKS | H5VL_CAP_FLAG_ITERATE | H5VL_CAP_FLAG_CREATION_ORDER))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, object, soft link, iterate, or creation order aren't supported with this connector\n");
+        return 0;
+    }
+
     TESTING_2("test setup")
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
@@ -5275,6 +5421,13 @@ test_object_visit_invalid_params(void)
 
     TESTING_MULTIPART("object visiting with invalid parameters");
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_ITERATE))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, or iterate aren't supported with this connector\n");
+        return 0;
+    }
+
     TESTING_2("test setup")
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
@@ -5527,6 +5680,14 @@ test_close_object(void)
 
     TESTING_MULTIPART("H5Oclose");
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_OBJECT_BASIC |
+                           H5VL_CAP_FLAG_DATASET_BASIC | H5VL_CAP_FLAG_ATTR_BASIC | H5VL_CAP_FLAG_STORED_DATATYPES))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, object, dataset, attribute, or stored datatype aren't supported with this connector\n");
+        return 0;
+    }
+
     TESTING_2("test setup")
 
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
@@ -5695,6 +5856,13 @@ test_close_object_invalid_params(void)
 
     TESTING("H5Oclose with an invalid object ID")
 
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_OBJECT_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file or object aren't supported with this connector\n");
+        return 0;
+    }
+
     if ((file_id = H5Fopen(vol_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
         HDprintf("    couldn't open file '%s'\n", vol_test_filename);
@@ -5742,6 +5910,13 @@ test_close_invalid_objects(void)
     herr_t status;
 
     TESTING_MULTIPART("H5Oclose invalid objects");
+
+    /* Make sure the connector supports the API functions being tested */
+    if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_OBJECT_BASIC))) {
+        SKIPPED();
+        HDprintf("    API functions for basic file, group, object, dataset, attribute, or stored datatype aren't supported with this connector\n");
+        return 0;
+    }
 
     TESTING_2("test setup")
 

--- a/vol_test.h
+++ b/vol_test.h
@@ -154,4 +154,5 @@ extern size_t n_tests_passed_g;
 extern size_t n_tests_failed_g;
 extern size_t n_tests_skipped_g;
 
+extern uint64_t vol_cap_flags;
 #endif


### PR DESCRIPTION
This PR is so far for serial test only.  I'll add the VOL capacity flag verification for the parallel test later.  

The following property functions don't have any corresponding flags:
```
H5Pcreate
H5Pset(get)_userblock
H5Pset_copy_object
H5Pset_alloc_time
H5Pset_attr_phase_change
H5Pset_fill_time
H5Pset_chunk
H5Pset_layout
H5Pset(get)_efile_prefix
H5Pset(get)_char_encoding
```