### PR TITLE
Skipping Two Parallel Test Cases Because of a File Sync Problem in the MPIO Driver

### DIFF
--- a/vol_dataset_test_parallel.c
+++ b/vol_dataset_test_parallel.c
@@ -6510,6 +6510,10 @@ test_overwrite_multi_chunk_dataset_same_shape_read(void)
 
     TESTING("several overwrites to dataset with multiple chunks using same shaped dataspaces")
 
+    /* Skip this test case until the file sync problem in the MPIO driver is solved */
+    SKIPPED();
+    return 0;
+
     /* Make sure the connector supports the API functions being tested */
     if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |
                            H5VL_CAP_FLAG_DATASET_MORE | H5VL_CAP_FLAG_GET_PLIST))) {
@@ -6970,6 +6974,10 @@ test_overwrite_multi_chunk_dataset_diff_shape_read(void)
     int      read_buf[DATASET_MULTI_CHUNK_OVERWRITE_DIFF_SPACE_READ_TEST_READ_BUF_DIMSIZE][DATASET_MULTI_CHUNK_OVERWRITE_DIFF_SPACE_READ_TEST_READ_BUF_DIMSIZE];
 
     TESTING("several overwrites to dataset with multiple chunks using differently shaped dataspaces")
+
+    /* Skip this test case until the file sync problem in the MPIO driver is solved */
+    SKIPPED();
+    return 0;
 
     /* Make sure the connector supports the API functions being tested */
     if (!(vol_cap_flags & (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |


### PR DESCRIPTION
There is a file sync problem in the MPIO driver for the test cases of:

1. several overwrites to dataset with multiple chunks using same shaped dataspaces. 
2. several overwrites to dataset with multiple chunks using different shaped dataspaces.