### PR TITLE
OESS-333/HDFFV-10964: Verify if H5Dvlen_get_buf_size returns the correct size

### DIFF
--- a/vol_dataset_test.h
+++ b/vol_dataset_test.h
@@ -319,4 +319,8 @@ int vol_dataset_test(void);
 #define DATASET_PARTIAL_CHUNK_READ_HYPER_SEL_TEST_GROUP_NAME      "read_partial_chunk_hyper_sel_test"
 #define DATASET_PARTIAL_CHUNK_READ_HYPER_SEL_TEST_DSET_NAME       "read_partial_chunk_hyper_sel_dset"
 
+#define DATASET_GET_VLEN_BUF_SIZE_DSET_SPACE_RANK 1
+#define DATASET_GET_VLEN_BUF_SIZE_DSET_SPACE_DIM  4
+#define DATASET_GET_VLEN_BUF_SIZE_GROUP_NAME      "get_vlen_buffer_size_group"
+#define DATASET_GET_VLEN_BUF_SIZE_DSET_NAME       "get_vlen_buffer_size_dset"
 #endif


### PR DESCRIPTION
The problem first appeared using DAOS-VOL.  H5Dvlen_get_buf_size always returned zero.  This test verifies if the fix worked correctly.  It needs to be run with DAOS-VOL.