### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,231 @@
+name: HDF5 API test CI
+
+on:
+  workflow_dispatch:
+  push:
+  pull_request:
+    branches: [ master ]
+    paths-ignore:
+      - '**.md'
+
+# Using concurrency to cancel any in-progress job or run
+concurrency:
+  group: ${{ github.workflow }}-${{ github.sha || github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build_and_test:
+    strategy:
+      matrix:
+        name:
+          - "Windows MSVC"
+          - "Ubuntu GCC"
+          - "Ubuntu GCC parallel (build only)"
+          - "MacOS Clang"
+
+        build_mode:
+          - text: " REL"
+            cmake: "Release"
+          - text: " DBG"
+            cmake: "Debug"
+
+        include:
+
+          # Exclude Windows for now since CMake code throws a
+          # fatal error about being unsupported on Windows.
+          # Unclear if the tests can be supported yet, but they
+          # should run fine on Windows. However, building of the
+          # test driver code needs to be updated to be optional
+
+          # Windows w/ MSVC + CMake
+          #- name: "Windows MSVC"
+          #  os: windows-2022
+          #  toolchain: ""
+          #  parallel: OFF
+          #  generator: "-G \"Visual Studio 17 2022\" -A x64"
+          #  run_tests: true
+
+          # Linux (Ubuntu) w/ GCC + CMake
+          - name: "Ubuntu GCC"
+            os: ubuntu-latest
+            parallel: OFF
+            toolchain: "config/toolchain/gcc.cmake"
+            generator: "-G Ninja"
+            run_tests: true
+
+          # Linux (Ubuntu) w/ GCC + CMake (parallel)
+          - name: "Ubuntu GCC parallel (build only)"
+            os: ubuntu-latest
+            parallel: ON
+            toolchain: "config/toolchain/gcc.cmake"
+            generator: "-G Ninja"
+            run_tests: false
+
+          # MacOS w/ Clang + CMake
+          - name: "MacOS Clang"
+            os: macos-11
+            parallel: OFF
+            toolchain: "config/toolchain/clang.cmake"
+            generator: "-G Ninja"
+            run_tests: true
+
+          #
+          # SPECIAL BUILDS
+          #
+
+          # -Werror Debug build
+          - name: "Ubuntu GCC -Werror Debug (build only)"
+            os: ubuntu-latest
+            parallel: OFF
+            toolchain: ""
+            generator: "-G Ninja"
+            flags: "-Wall -Wextra -Werror"
+            run_tests: false
+            build_mode:
+              text: " DBG"
+              cmake: "Debug"
+
+          # -Werror Release build
+          - name: "Ubuntu GCC -Werror Release (build only)"
+            os: ubuntu-latest
+            parallel: OFF
+            toolchain: ""
+            generator: "-G Ninja"
+            flags: "-Wall -Wextra -Werror"
+            run_tests: false
+            build_mode:
+              text: " REL"
+              cmake: "Release"
+
+          # -Werror Debug parallel build
+          - name: "Ubuntu GCC -Werror Debug parallel (build only)"
+            os: ubuntu-latest
+            parallel: ON
+            toolchain: ""
+            generator: "-G Ninja"
+            flags: "-Wall -Wextra -Werror"
+            run_tests: false
+            build_mode:
+              text: " DBG"
+              cmake: "Debug"
+
+          # -Werror Release parallel build
+          - name: "Ubuntu GCC -Werror Release parallel (build only)"
+            os: ubuntu-latest
+            parallel: ON
+            toolchain: ""
+            generator: "-G Ninja"
+            flags: "-Wall -Wextra -Werror"
+            run_tests: false
+            build_mode:
+              text: " REL"
+              cmake: "Release"
+
+        exclude:
+
+          # Exclude Windows for now since CMake code throws a
+          # fatal error about being unsupported on Windows.
+          # Unclear if the tests can be supported yet, but they
+          # should run fine on Windows. However, building of the
+          # test driver code needs to be updated to be optional
+          - name: "Windows MSVC"
+
+          # Only test a few debug builds
+          - name: "Windows MSVC"
+            build_mode:
+              text: " DBG"
+              cmake: "Debug"
+
+          - name: "MacOS Clang"
+            build_mode:
+              text: " DBG"
+              cmake: "Debug"
+
+    # Sets the job's name from the properties
+    name: "${{ matrix.name }}${{ matrix.build_mode.text }}"
+
+    # The type of runner that the job will run on
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Dump matrix context
+        run: echo '${{ toJSON(matrix) }}'
+
+      - name: Checkout API tests
+        uses: actions/checkout@v3
+        with:
+          path: api-tests
+
+      - name: Checkout HDF5
+        uses: actions/checkout@v3
+        with:
+          repository: HDFGroup/hdf5
+          path: hdf5
+
+      - name: Install Dependencies (Linux)
+        run: sudo apt-get install ninja-build
+        if: matrix.os == 'ubuntu-latest'
+
+      - name: Install Dependencies (Linux, parallel)
+        run: |
+           sudo apt update
+           sudo apt install ninja-build
+           sudo apt install openmpi-bin openmpi-common mpi-default-dev
+           echo "CC=mpicc" >> $GITHUB_ENV
+           sudo apt install libaec0 libaec-dev
+        if: (matrix.parallel == 'ON')
+
+      - name: Install Dependencies (Windows)
+        run: choco install ninja
+        if: matrix.os == 'windows-latest'
+
+      - name: Install Dependencies (macOS)
+        run: brew install ninja
+        if: matrix.os == 'macos-11'
+
+      - name: Set environment for MSVC (Windows)
+        run: |
+          # Set these environment variables so CMake picks the correct compiler
+          echo "CXX=cl.exe" >> $GITHUB_ENV
+          echo "CC=cl.exe" >> $GITHUB_ENV
+        if: matrix.os == 'windows-latest'
+
+      - name: Install HDF5
+        run: |
+          cd "$GITHUB_WORKSPACE/hdf5"
+          mkdir "build"
+          cd "build"
+          cmake ${{ matrix.generator }} \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_mode.cmake }} \
+            -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/hdf5_build \
+            -DCMAKE_TOOLCHAIN_FILE=${{ matrix.toolchain }} \
+            -DBUILD_SHARED_LIBS=ON \
+            -DHDF5_ENABLE_ALL_WARNINGS=ON \
+            -DHDF5_ENABLE_PARALLEL:BOOL=${{ matrix.parallel }} \
+            ..
+          cmake --build . --parallel 3 --config ${{ matrix.build_mode.cmake }}
+          cmake --install . --config ${{ matrix.build_mode.cmake }}
+        shell: bash
+
+      - name: Install API tests
+        run: |
+          cd "$GITHUB_WORKSPACE/api-tests"
+          mkdir "build"
+          cd "build"
+          cmake ${{ matrix.generator }} \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_mode.cmake }} \
+            -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/api_tests_build \
+            -DCMAKE_C_FLAGS="${{ matrix.flags }}" \
+            -DHDF5_DIR=$GITHUB_WORKSPACE/hdf5_build \
+            -DHDF5_VOL_TEST_ENABLE_PART=ON \
+            -DHDF5_VOL_TEST_ENABLE_PARALLEL=${{ matrix.parallel }} \
+            -DHDF5_VOL_TEST_ENABLE_ASYNC=ON \
+            ..
+          cmake --build . --parallel 3 --config ${{ matrix.build_mode.cmake }}
+        shell: bash
+
+      - name: Run API tests
+        run: |
+          cd "$GITHUB_WORKSPACE/api-tests/build"
+          ctest --build . --parallel 2 -C ${{ matrix.build_mode.cmake }} -V
+        if: (matrix.run_tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 2.8.12.2 FATAL_ERROR)
 project(HDF5_VOL_TEST C)
 
+if (POLICY CMP0074)
+  # find_package() uses <PackageName>_ROOT variables.
+  cmake_policy (SET CMP0074 NEW)
+endif ()
+
 #------------------------------------------------------------------------------
 # Setup install and output Directories
 #------------------------------------------------------------------------------
@@ -92,6 +97,11 @@ include_directories(
 # External dependencies
 #------------------------------------------------------------------------------
 # HDF5
+
+if (POLICY CMP0074)
+  SET(HDF5_ROOT ${HDF5_DIR})
+endif ()
+
 # Save a copy of HDF5_DIR set by the user.
 SET(ORIG_HDF5_DIR ${HDF5_DIR})
 find_package(HDF5 NO_MODULE NAMES hdf5 COMPONENTS C shared)
@@ -364,6 +374,8 @@ if(HDF5_VOL_TEST_SERVER)
     )
   else()
     foreach(vol_test ${vol_tests})
+      set(last_vol_test "")
+
       add_test(NAME "h5vl_test_${vol_test}"
         COMMAND $<TARGET_FILE:h5vl_test_driver>
         --server ${HDF5_VOL_TEST_SERVER}
@@ -371,6 +383,10 @@ if(HDF5_VOL_TEST_SERVER)
         --serial
         ${HDF5_VOL_TEST_DRIVER_EXTRA_FLAGS}
       )
+
+      set_tests_properties("h5vl_test_${vol_test}" PROPERTIES DEPENDS "${last_vol_test}")
+
+      set(last_vol_test "h5vl_test_${vol_test}")
     endforeach()
   endif()
 
@@ -429,10 +445,16 @@ else()
       COMMAND $<TARGET_FILE:h5vl_test>
     )
   else()
+    set(last_vol_test "")
+
     foreach(vol_test ${vol_tests})
       add_test(NAME "h5vl_test_${vol_test}"
         COMMAND $<TARGET_FILE:h5vl_test> ${vol_test}
       )
+
+      set_tests_properties("h5vl_test_${vol_test}" PROPERTIES DEPENDS "${last_vol_test}")
+
+      set(last_vol_test "h5vl_test_${vol_test}")
     endforeach()
   endif()
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![HDF5 API test CI](https://github.com/HDFGroup/vol-tests/actions/workflows/main.yml/badge.svg)](https://github.com/HDFGroup/vol-tests/actions/workflows/main.yml)
 [![Test HDF5 ADIOS2 VOL](https://github.com/HDFGroup/vol-tests/actions/workflows/adios2.yml/badge.svg)](https://github.com/HDFGroup/vol-tests/actions/workflows/adios2.yml)
 [![Test HDF5 async VOL](https://github.com/HDFGroup/vol-tests/actions/workflows/async.yml/badge.svg)](https://github.com/HDFGroup/vol-tests/actions/workflows/async.yml)
 [![Test HDF5 cache VOL](https://github.com/HDFGroup/vol-tests/actions/workflows/cache.yml/badge.svg)](https://github.com/HDFGroup/vol-tests/actions/workflows/cache.yml)

--- a/driver/kwsys/ProcessUNIX.c
+++ b/driver/kwsys/ProcessUNIX.c
@@ -1474,7 +1474,18 @@ static void kwsysProcessVolatileFree(volatile void* p)
 #  pragma clang diagnostic push
 #  pragma clang diagnostic ignored "-Wcast-qual"
 #endif
+
+#if defined(__GNUC__) && (((__GNUC__ * 100) + __GNUC_MINOR__) >= 406)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wcast-qual"
+#endif
+
   free((void*)p); /* The cast will silence most compilers, but not clang.  */
+
+#if defined(__GNUC__) && (((__GNUC__ * 100) + __GNUC_MINOR__) >= 406)
+#  pragma GCC diagnostic pop
+#endif
+
 #if defined(__clang__) && !defined(__INTEL_COMPILER)
 #  pragma clang diagnostic pop
 #endif

--- a/vol_test.c
+++ b/vol_test.c
@@ -118,7 +118,8 @@ vol_test_run(void)
 static int
 get_vol_cap_flags(const char *connector_name)
 {
-    hid_t connector_id, fapl_id;
+    hid_t connector_id = H5I_INVALID_HID;
+    hid_t fapl_id      = H5I_INVALID_HID;
 
     if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) {
         H5_FAILED();

--- a/vol_test_parallel.c
+++ b/vol_test_parallel.c
@@ -170,7 +170,8 @@ error:
 static int
 get_vol_cap_flags(const char *connector_name)
 {
-    hid_t connector_id, fapl_id;
+    hid_t connector_id = H5I_INVALID_HID;
+    hid_t fapl_id      = H5I_INVALID_HID;
 
     if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0) {
         H5_FAILED();


### PR DESCRIPTION
Adds a workflow file to test the VOL tests with the native VOL using MacOS REL and a variety of Ubuntu configs, including -Werror in serial and parallel. Windows is excluded for now because the CMakeLists file throws a fatal error about Windows being unsupported for the VOL tests. Unclear why that is, but it probably has to do with the test driver code being built non-optionally. I'm fixing that over in the VOL tests -> library integration branch.