### PR TITLE
Add verbose flag to ctest in VOL workflows

### DIFF
--- a/.github/workflows/adios2.yml
+++ b/.github/workflows/adios2.yml
@@ -51,7 +51,7 @@ jobs:
         cd build
         cmake .. -DHDF5_DIR=/usr/local -DHDF5_VOL_TEST_ENABLE_PARALLEL:BOOL=ON -DHDF5_VOL_TEST_ENABLE_ASYNC:BOOL=ON -DHDF5_VOL_TEST_ENABLE_PART:BOOL=ON
         make
-        ctest
+        ctest -V
         pwd
         ls
     - name: Upload

--- a/.github/workflows/async.yml
+++ b/.github/workflows/async.yml
@@ -74,7 +74,7 @@ jobs:
         cd build
         cmake .. -DHDF5_DIR=/usr/local -DHDF5_VOL_TEST_ENABLE_PARALLEL:BOOL=ON -DHDF5_VOL_TEST_ENABLE_ASYNC:BOOL=ON -DHDF5_VOL_TEST_ENABLE_PART:BOOL=ON
         make
-        ctest
+        ctest -V
         pwd
         ls
         ./bin/h5vl_test | tee ../output.txt

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -91,7 +91,7 @@ jobs:
         cd build
         cmake .. -DHDF5_DIR=/usr/local -DHDF5_VOL_TEST_ENABLE_PARALLEL:BOOL=ON -DHDF5_VOL_TEST_ENABLE_ASYNC:BOOL=ON -DHDF5_VOL_TEST_ENABLE_PART:BOOL=ON
         make
-        ctest
+        ctest -V
         pwd
         ls
         

--- a/.github/workflows/log.yml
+++ b/.github/workflows/log.yml
@@ -57,7 +57,7 @@ jobs:
         cd build
         cmake .. -DHDF5_DIR=/usr/local -DHDF5_VOL_TEST_ENABLE_PARALLEL:BOOL=ON -DHDF5_VOL_TEST_ENABLE_ASYNC:BOOL=ON -DHDF5_VOL_TEST_ENABLE_PART:BOOL=ON
         make
-        ctest
+        ctest -V
         pwd
         ls
     - name: Upload

--- a/.github/workflows/pass.yml
+++ b/.github/workflows/pass.yml
@@ -53,7 +53,7 @@ jobs:
         cd build
         cmake .. -DHDF5_DIR=/usr/local -DHDF5_VOL_TEST_ENABLE_PARALLEL:BOOL=ON -DHDF5_VOL_TEST_ENABLE_ASYNC:BOOL=ON -DHDF5_VOL_TEST_ENABLE_PART:BOOL=ON
         make
-        ctest
+        ctest -V
         pwd
         ls
         

--- a/.github/workflows/rest.yml
+++ b/.github/workflows/rest.yml
@@ -40,4 +40,4 @@ jobs:
         cd vol-rest/build
         cmake ..
         make
-        ctest
+        ctest -V


### PR DESCRIPTION
Shows output from ctest so we can see why VOL tests fail with different connectors