### PR TITLE
Implement fill value tests

### DIFF
--- a/vol_dataset_test.c
+++ b/vol_dataset_test.c
@@ -2056,6 +2056,7 @@ test_create_dataset_creation_properties(void)
     hid_t   dset_id = H5I_INVALID_HID, dcpl_id = H5I_INVALID_HID;
     hid_t   dset_dtype = H5I_INVALID_HID, compact_dtype = H5I_INVALID_HID;
     hid_t   fspace_id = H5I_INVALID_HID, compact_fspace_id = H5I_INVALID_HID;
+    void *read_buf = NULL;
 
     TESTING_MULTIPART("dataset creation properties");
 
@@ -2388,7 +2389,225 @@ test_create_dataset_creation_properties(void)
         }
         PART_END(DCPL_fill_time_property_test);
 
-        /* TODO: Test the fill value property */
+        PART_BEGIN(DCPL_fill_value_test)
+        {
+            TESTING_2("fill values");
+
+            int int_fill_value = DATASET_FILL_VALUE_TEST_INT_FILL_VALUE;
+            double double_fill_value = DATASET_FILL_VALUE_TEST_DOUBLE_FILL_VALUE;
+            
+            void *val = NULL;
+            size_t num_elems = 1;
+            hid_t type_id = H5I_INVALID_HID;
+            
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_FILL_VALUES)) {
+                SKIPPED();
+                HDprintf("    dataset fill values are not supported by this VOL connector\n");
+                PART_EMPTY(DCPL_fill_value_test);
+            }
+
+            /* Integer Fill Value */
+            if ((dcpl_id = H5Pcreate(H5P_DATASET_CREATE)) < 0) {
+                H5_FAILED();
+                HDprintf("    couldn't create DCPL\n");
+                PART_ERROR(DCPL_fill_value_test);
+            }
+
+            if (H5Pset_fill_value(dcpl_id, DATASET_FILL_VALUE_TEST_INT_TYPE, (const void *) &int_fill_value) < 0) {
+                H5_FAILED();
+                HDprintf("    couldn't set integer fill value in property list");
+                PART_ERROR(DCPL_fill_value_test);
+            }
+
+            if ((dset_id = H5Dcreate(group_id, DATASET_FILL_VALUE_TEST_DSET_NAME1, DATASET_FILL_VALUE_TEST_INT_TYPE, fspace_id, H5P_DEFAULT, dcpl_id, H5P_DEFAULT)) < 0) {
+                H5_FAILED();
+                HDprintf("    couldn't create dataset with integer fill value");
+                PART_ERROR(DCPL_fill_value_test);
+            }
+
+            if ((H5Sget_simple_extent_dims(fspace_id, dims, NULL)) < 0) {
+                H5_FAILED();
+                HDprintf("    couldn't get dataspace dimensions");
+                PART_ERROR(DCPL_fill_value_test);
+            }
+
+            for (int i = 0; i < DATASET_CREATION_PROPERTIES_TEST_SHAPE_RANK; i++)
+                num_elems *= (size_t) dims[i];
+            
+            if ((read_buf = HDcalloc(num_elems, sizeof(DATASET_FILL_VALUE_TEST_INT_TYPE))) == NULL) {
+                H5_FAILED();
+                HDprintf("    couldn't allocate memory for read buffer");
+                PART_ERROR(DCPL_fill_value_test);
+            }
+
+            if (H5Dread(dset_id, DATASET_FILL_VALUE_TEST_INT_TYPE, H5S_ALL, H5S_ALL, H5P_DEFAULT, read_buf) < 0) {
+                H5_FAILED();
+                HDprintf("    couldn't read from dataset");
+                PART_ERROR(DCPL_fill_value_test);
+            }
+
+            for (size_t i = 0; i < num_elems; i++) {
+                val = (int*)(read_buf) + i;
+
+                if (*(int*) val != DATASET_FILL_VALUE_TEST_INT_FILL_VALUE) {
+                    H5_FAILED();
+                    HDprintf("    incorrect value read from dataset");
+                    PART_ERROR(DCPL_fill_value_test);
+                }
+            }
+
+            if (H5Dclose(dset_id) < 0) {
+                H5_FAILED();
+                HDprintf("    couldn't close integer fill value dataset");
+                PART_ERROR(DCPL_fill_value_test);
+            }
+
+            if (H5Pclose(dcpl_id) < 0) {
+                H5_FAILED();
+                HDprintf("    couldn't close dcpl");
+                PART_ERROR(DCPL_fill_value_test);
+            }
+
+            HDfree(read_buf);
+            read_buf = NULL;
+
+            /* Double fill value */
+            if ((dcpl_id = H5Pcreate(H5P_DATASET_CREATE)) == H5I_INVALID_HID) {
+                H5_FAILED();
+                HDprintf("    couldn't create dcpl");
+                PART_ERROR(DCPL_fill_value_test);
+            }
+
+            if ((H5Pset_fill_value(dcpl_id, DATASET_FILL_VALUE_TEST_DOUBLE_TYPE, (const void*) &double_fill_value)) < 0) {
+                H5_FAILED();
+                HDprintf("    couldn't set double fill value in property list");
+                PART_ERROR(DCPL_fill_value_test);
+            }
+            
+            if ((dset_id = H5Dcreate2(group_id, DATASET_FILL_VALUE_TEST_DSET_NAME2, DATASET_FILL_VALUE_TEST_DOUBLE_TYPE, fspace_id, H5P_DEFAULT, dcpl_id, H5P_DEFAULT)) < 0) {
+                                H5_FAILED();
+                HDprintf("    couldn't create dataset with double fill value");
+                PART_ERROR(DCPL_fill_value_test);
+            }
+
+
+            if ((read_buf = HDcalloc(num_elems, sizeof(DATASET_FILL_VALUE_TEST_DOUBLE_TYPE))) == NULL) {
+                H5_FAILED();
+                HDprintf("    couldn't allocate memory for read buffer");
+                PART_ERROR(DCPL_fill_value_test);
+            }
+
+            if (H5Dread(dset_id, DATASET_FILL_VALUE_TEST_DOUBLE_TYPE, H5S_ALL, H5S_ALL, H5P_DEFAULT, read_buf) < 0) {
+                H5_FAILED();
+                HDprintf("    couldn't read from dataset");
+                PART_ERROR(DCPL_fill_value_test);
+            }
+
+            for (size_t i = 0; i < num_elems; i++) {
+                val = (double*)(read_buf) + i;
+
+                if (*(double*) val != DATASET_FILL_VALUE_TEST_DOUBLE_FILL_VALUE) {
+                    H5_FAILED();
+                    HDprintf("    incorrect value read from dataset");
+                    PART_ERROR(DCPL_fill_value_test);
+                }
+            }
+
+            if (H5Dclose(dset_id) < 0) {
+                H5_FAILED();
+                HDprintf("    couldn't close double fill value dataset");
+                PART_ERROR(DCPL_fill_value_test);
+            }
+
+            if (H5Pclose(dcpl_id) < 0) {
+                H5_FAILED();
+                HDprintf("    couldn't close dcpl");
+                PART_ERROR(DCPL_fill_value_test);
+            }
+
+            HDfree(read_buf);
+            read_buf = NULL;
+
+            /* Fixed-length string fill value */
+            if ((dcpl_id = H5Pcreate(H5P_DATASET_CREATE)) == H5I_INVALID_HID) {
+                H5_FAILED();
+                HDprintf("    couldn't create dcpl");
+                PART_ERROR(DCPL_fill_value_test);
+            }
+            
+            if ((type_id = H5Tcopy(H5T_C_S1)) < 0) {
+                H5_FAILED();
+                HDprintf("    couldn't copy string datatype");
+                PART_ERROR(DCPL_fill_value_test);
+            }
+
+            if ((H5Tset_size(type_id, DATASET_FILL_VALUE_TEST_STRING_SIZE)) < 0) {
+                H5_FAILED();
+                HDprintf("    couldn't set size of string datatype");
+                PART_ERROR(DCPL_fill_value_test); 
+            }
+
+            if ((H5Pset_fill_value(dcpl_id, type_id, (const void*) DATASET_FILL_VALUE_TEST_STRING_FILL_VALUE)) < 0) {
+                H5_FAILED();
+                HDprintf("    couldn't set string fill value in property list");
+                PART_ERROR(DCPL_fill_value_test);
+            }
+            
+            if ((dset_id = H5Dcreate2(group_id, DATASET_FILL_VALUE_TEST_DSET_NAME3, type_id, fspace_id, H5P_DEFAULT, dcpl_id, H5P_DEFAULT)) < 0) {
+                                H5_FAILED();
+                HDprintf("    couldn't create dataset with string fill value");
+                PART_ERROR(DCPL_fill_value_test);
+            }
+
+            if ((read_buf = HDcalloc(num_elems, DATASET_FILL_VALUE_TEST_STRING_SIZE)) == NULL) {
+                H5_FAILED();
+                HDprintf("    couldn't allocate memory for read buffer");
+                PART_ERROR(DCPL_fill_value_test);
+            }
+
+            if (H5Dread(dset_id, type_id, H5S_ALL, H5S_ALL, H5P_DEFAULT, read_buf) < 0) {
+                H5_FAILED();
+                HDprintf("    couldn't read from dataset");
+                PART_ERROR(DCPL_fill_value_test);
+            }
+
+            for (size_t i = 0; i < num_elems; i++) {
+                char val_str[DATASET_FILL_VALUE_TEST_STRING_SIZE+ 1];
+
+                memcpy(val_str, ((char*) read_buf) + i * DATASET_FILL_VALUE_TEST_STRING_SIZE, DATASET_FILL_VALUE_TEST_STRING_SIZE);
+                val_str[DATASET_FILL_VALUE_TEST_STRING_SIZE] = '\0';
+
+                if (strcmp(val_str, DATASET_FILL_VALUE_TEST_STRING_FILL_VALUE)) {
+                    H5_FAILED();
+                    HDprintf("    incorrect value read fromstring  dataset");
+                    PART_ERROR(DCPL_fill_value_test);
+                }
+            }
+
+            if (H5Dclose(dset_id) < 0) {
+                H5_FAILED();
+                HDprintf("    couldn't close double fill value dataset");
+                PART_ERROR(DCPL_fill_value_test);
+            }
+
+            if (H5Pclose(dcpl_id) < 0) {
+                H5_FAILED();
+                HDprintf("    couldn't close dcpl");
+                PART_ERROR(DCPL_fill_value_test);
+            }
+
+            if (H5Tclose(type_id) < 0) {
+                H5_FAILED();
+                HDprintf("    couldn't close string type");
+                PART_ERROR(DCPL_fill_value_test);
+            }
+
+            HDfree(read_buf);
+            read_buf = NULL;
+
+            PASSED();
+        }
+        PART_END(DCPL_fill_value_test);
 
         /* Test filters */
         PART_BEGIN(DCPL_filters_test)
@@ -2689,6 +2908,8 @@ test_create_dataset_creation_properties(void)
 
     TESTING_2("test cleanup");
 
+    if (read_buf)
+        HDfree(read_buf);
     if (H5Sclose(compact_fspace_id) < 0)
         TEST_ERROR;
     if (H5Sclose(fspace_id) < 0)
@@ -2709,6 +2930,9 @@ test_create_dataset_creation_properties(void)
     return 0;
 
 error:
+    if (read_buf)
+        HDfree(read_buf);
+
     H5E_BEGIN_TRY
     {
         H5Sclose(compact_fspace_id);

--- a/vol_dataset_test.c
+++ b/vol_dataset_test.c
@@ -2056,7 +2056,7 @@ test_create_dataset_creation_properties(void)
     hid_t   dset_id = H5I_INVALID_HID, dcpl_id = H5I_INVALID_HID;
     hid_t   dset_dtype = H5I_INVALID_HID, compact_dtype = H5I_INVALID_HID;
     hid_t   fspace_id = H5I_INVALID_HID, compact_fspace_id = H5I_INVALID_HID;
-    void *read_buf = NULL;
+    void   *read_buf = NULL;
 
     TESTING_MULTIPART("dataset creation properties");
 
@@ -2393,13 +2393,13 @@ test_create_dataset_creation_properties(void)
         {
             TESTING_2("fill values");
 
-            int int_fill_value = DATASET_FILL_VALUE_TEST_INT_FILL_VALUE;
+            int    int_fill_value    = DATASET_FILL_VALUE_TEST_INT_FILL_VALUE;
             double double_fill_value = DATASET_FILL_VALUE_TEST_DOUBLE_FILL_VALUE;
-            
-            void *val = NULL;
+
+            void  *val       = NULL;
             size_t num_elems = 1;
-            hid_t type_id = H5I_INVALID_HID;
-            
+            hid_t  type_id   = H5I_INVALID_HID;
+
             if (!(vol_cap_flags_g & H5VL_CAP_FLAG_FILL_VALUES)) {
                 SKIPPED();
                 HDprintf("    dataset fill values are not supported by this VOL connector\n");
@@ -2413,13 +2413,16 @@ test_create_dataset_creation_properties(void)
                 PART_ERROR(DCPL_fill_value_test);
             }
 
-            if (H5Pset_fill_value(dcpl_id, DATASET_FILL_VALUE_TEST_INT_TYPE, (const void *) &int_fill_value) < 0) {
+            if (H5Pset_fill_value(dcpl_id, DATASET_FILL_VALUE_TEST_INT_TYPE, (const void *)&int_fill_value) <
+                0) {
                 H5_FAILED();
                 HDprintf("    couldn't set integer fill value in property list");
                 PART_ERROR(DCPL_fill_value_test);
             }
 
-            if ((dset_id = H5Dcreate(group_id, DATASET_FILL_VALUE_TEST_DSET_NAME1, DATASET_FILL_VALUE_TEST_INT_TYPE, fspace_id, H5P_DEFAULT, dcpl_id, H5P_DEFAULT)) < 0) {
+            if ((dset_id =
+                     H5Dcreate(group_id, DATASET_FILL_VALUE_TEST_DSET_NAME1, DATASET_FILL_VALUE_TEST_INT_TYPE,
+                               fspace_id, H5P_DEFAULT, dcpl_id, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
                 HDprintf("    couldn't create dataset with integer fill value");
                 PART_ERROR(DCPL_fill_value_test);
@@ -2432,24 +2435,25 @@ test_create_dataset_creation_properties(void)
             }
 
             for (int i = 0; i < DATASET_CREATION_PROPERTIES_TEST_SHAPE_RANK; i++)
-                num_elems *= (size_t) dims[i];
-            
+                num_elems *= (size_t)dims[i];
+
             if ((read_buf = HDcalloc(num_elems, sizeof(DATASET_FILL_VALUE_TEST_INT_TYPE))) == NULL) {
                 H5_FAILED();
                 HDprintf("    couldn't allocate memory for read buffer");
                 PART_ERROR(DCPL_fill_value_test);
             }
 
-            if (H5Dread(dset_id, DATASET_FILL_VALUE_TEST_INT_TYPE, H5S_ALL, H5S_ALL, H5P_DEFAULT, read_buf) < 0) {
+            if (H5Dread(dset_id, DATASET_FILL_VALUE_TEST_INT_TYPE, H5S_ALL, H5S_ALL, H5P_DEFAULT, read_buf) <
+                0) {
                 H5_FAILED();
                 HDprintf("    couldn't read from dataset");
                 PART_ERROR(DCPL_fill_value_test);
             }
 
             for (size_t i = 0; i < num_elems; i++) {
-                val = (int*)(read_buf) + i;
+                val = (int *)(read_buf) + i;
 
-                if (*(int*) val != DATASET_FILL_VALUE_TEST_INT_FILL_VALUE) {
+                if (*(int *)val != DATASET_FILL_VALUE_TEST_INT_FILL_VALUE) {
                     H5_FAILED();
                     HDprintf("    incorrect value read from dataset");
                     PART_ERROR(DCPL_fill_value_test);
@@ -2478,18 +2482,20 @@ test_create_dataset_creation_properties(void)
                 PART_ERROR(DCPL_fill_value_test);
             }
 
-            if ((H5Pset_fill_value(dcpl_id, DATASET_FILL_VALUE_TEST_DOUBLE_TYPE, (const void*) &double_fill_value)) < 0) {
+            if ((H5Pset_fill_value(dcpl_id, DATASET_FILL_VALUE_TEST_DOUBLE_TYPE,
+                                   (const void *)&double_fill_value)) < 0) {
                 H5_FAILED();
                 HDprintf("    couldn't set double fill value in property list");
                 PART_ERROR(DCPL_fill_value_test);
             }
-            
-            if ((dset_id = H5Dcreate2(group_id, DATASET_FILL_VALUE_TEST_DSET_NAME2, DATASET_FILL_VALUE_TEST_DOUBLE_TYPE, fspace_id, H5P_DEFAULT, dcpl_id, H5P_DEFAULT)) < 0) {
-                                H5_FAILED();
+
+            if ((dset_id = H5Dcreate2(group_id, DATASET_FILL_VALUE_TEST_DSET_NAME2,
+                                      DATASET_FILL_VALUE_TEST_DOUBLE_TYPE, fspace_id, H5P_DEFAULT, dcpl_id,
+                                      H5P_DEFAULT)) < 0) {
+                H5_FAILED();
                 HDprintf("    couldn't create dataset with double fill value");
                 PART_ERROR(DCPL_fill_value_test);
             }
-
 
             if ((read_buf = HDcalloc(num_elems, sizeof(DATASET_FILL_VALUE_TEST_DOUBLE_TYPE))) == NULL) {
                 H5_FAILED();
@@ -2497,16 +2503,17 @@ test_create_dataset_creation_properties(void)
                 PART_ERROR(DCPL_fill_value_test);
             }
 
-            if (H5Dread(dset_id, DATASET_FILL_VALUE_TEST_DOUBLE_TYPE, H5S_ALL, H5S_ALL, H5P_DEFAULT, read_buf) < 0) {
+            if (H5Dread(dset_id, DATASET_FILL_VALUE_TEST_DOUBLE_TYPE, H5S_ALL, H5S_ALL, H5P_DEFAULT,
+                        read_buf) < 0) {
                 H5_FAILED();
                 HDprintf("    couldn't read from dataset");
                 PART_ERROR(DCPL_fill_value_test);
             }
 
             for (size_t i = 0; i < num_elems; i++) {
-                val = (double*)(read_buf) + i;
+                val = (double *)(read_buf) + i;
 
-                if (*(double*) val != DATASET_FILL_VALUE_TEST_DOUBLE_FILL_VALUE) {
+                if (!(VL_DBL_REL_EQUAL(*(double*)val, DATASET_FILL_VALUE_TEST_DOUBLE_FILL_VALUE, 0.0000001))) {
                     H5_FAILED();
                     HDprintf("    incorrect value read from dataset");
                     PART_ERROR(DCPL_fill_value_test);
@@ -2534,7 +2541,7 @@ test_create_dataset_creation_properties(void)
                 HDprintf("    couldn't create dcpl");
                 PART_ERROR(DCPL_fill_value_test);
             }
-            
+
             if ((type_id = H5Tcopy(H5T_C_S1)) < 0) {
                 H5_FAILED();
                 HDprintf("    couldn't copy string datatype");
@@ -2544,17 +2551,19 @@ test_create_dataset_creation_properties(void)
             if ((H5Tset_size(type_id, DATASET_FILL_VALUE_TEST_STRING_SIZE)) < 0) {
                 H5_FAILED();
                 HDprintf("    couldn't set size of string datatype");
-                PART_ERROR(DCPL_fill_value_test); 
+                PART_ERROR(DCPL_fill_value_test);
             }
 
-            if ((H5Pset_fill_value(dcpl_id, type_id, (const void*) DATASET_FILL_VALUE_TEST_STRING_FILL_VALUE)) < 0) {
+            if ((H5Pset_fill_value(dcpl_id, type_id,
+                                   (const void *)DATASET_FILL_VALUE_TEST_STRING_FILL_VALUE)) < 0) {
                 H5_FAILED();
                 HDprintf("    couldn't set string fill value in property list");
                 PART_ERROR(DCPL_fill_value_test);
             }
-            
-            if ((dset_id = H5Dcreate2(group_id, DATASET_FILL_VALUE_TEST_DSET_NAME3, type_id, fspace_id, H5P_DEFAULT, dcpl_id, H5P_DEFAULT)) < 0) {
-                                H5_FAILED();
+
+            if ((dset_id = H5Dcreate2(group_id, DATASET_FILL_VALUE_TEST_DSET_NAME3, type_id, fspace_id,
+                                      H5P_DEFAULT, dcpl_id, H5P_DEFAULT)) < 0) {
+                H5_FAILED();
                 HDprintf("    couldn't create dataset with string fill value");
                 PART_ERROR(DCPL_fill_value_test);
             }
@@ -2572,9 +2581,10 @@ test_create_dataset_creation_properties(void)
             }
 
             for (size_t i = 0; i < num_elems; i++) {
-                char val_str[DATASET_FILL_VALUE_TEST_STRING_SIZE+ 1];
+                char val_str[DATASET_FILL_VALUE_TEST_STRING_SIZE + 1];
 
-                memcpy(val_str, ((char*) read_buf) + i * DATASET_FILL_VALUE_TEST_STRING_SIZE, DATASET_FILL_VALUE_TEST_STRING_SIZE);
+                memcpy(val_str, ((char *)read_buf) + i * DATASET_FILL_VALUE_TEST_STRING_SIZE,
+                       DATASET_FILL_VALUE_TEST_STRING_SIZE);
                 val_str[DATASET_FILL_VALUE_TEST_STRING_SIZE] = '\0';
 
                 if (strcmp(val_str, DATASET_FILL_VALUE_TEST_STRING_FILL_VALUE)) {
@@ -2908,8 +2918,11 @@ test_create_dataset_creation_properties(void)
 
     TESTING_2("test cleanup");
 
-    if (read_buf)
+    if (read_buf) {
         HDfree(read_buf);
+        read_buf = NULL;
+    }
+
     if (H5Sclose(compact_fspace_id) < 0)
         TEST_ERROR;
     if (H5Sclose(fspace_id) < 0)

--- a/vol_dataset_test.c
+++ b/vol_dataset_test.c
@@ -2513,7 +2513,8 @@ test_create_dataset_creation_properties(void)
             for (size_t i = 0; i < num_elems; i++) {
                 val = (double *)(read_buf) + i;
 
-                if (!(VL_DBL_REL_EQUAL(*(double*)val, DATASET_FILL_VALUE_TEST_DOUBLE_FILL_VALUE, 0.0000001))) {
+                if (!(VL_DBL_REL_EQUAL(*(double *)val, DATASET_FILL_VALUE_TEST_DOUBLE_FILL_VALUE,
+                                       0.0000001))) {
                     H5_FAILED();
                     HDprintf("    incorrect value read from dataset");
                     PART_ERROR(DCPL_fill_value_test);

--- a/vol_dataset_test.h
+++ b/vol_dataset_test.h
@@ -126,6 +126,16 @@ int vol_dataset_test(void);
 #define DATASET_PROPERTY_LIST_TEST_DSET_NAME3    "property_list_test_dataset3"
 #define DATASET_PROPERTY_LIST_TEST_DSET_NAME4    "property_list_test_dataset4"
 
+#define DATASET_FILL_VALUE_TEST_DSET_NAME1          "dataset_fill_value_test_dataset1"
+#define DATASET_FILL_VALUE_TEST_DSET_NAME2          "dataset_fill_value_test_dataset2"
+#define DATASET_FILL_VALUE_TEST_DSET_NAME3          "dataset_fill_value_test_dataset3"
+#define DATASET_FILL_VALUE_TEST_INT_TYPE            H5T_NATIVE_INT
+#define DATASET_FILL_VALUE_TEST_INT_FILL_VALUE      1
+#define DATASET_FILL_VALUE_TEST_DOUBLE_TYPE         H5T_NATIVE_DOUBLE
+#define DATASET_FILL_VALUE_TEST_DOUBLE_FILL_VALUE   2.002 
+#define DATASET_FILL_VALUE_TEST_STRING_FILL_VALUE   "abcdefgh"
+#define DATASET_FILL_VALUE_TEST_STRING_SIZE         8 /* No null terminator for fixed length string*/
+
 #define DATASET_SMALL_READ_TEST_ALL_DSET_SPACE_RANK 3
 #define DATASET_SMALL_READ_TEST_ALL_DSET_DTYPESIZE  sizeof(int)
 #define DATASET_SMALL_READ_TEST_ALL_DSET_DTYPE      H5T_NATIVE_INT

--- a/vol_dataset_test.h
+++ b/vol_dataset_test.h
@@ -23,6 +23,13 @@ int vol_dataset_test(void);
  *                                              *
  ************************************************/
 
+/* Check if the relative difference is smaller than a
+*  predefined value M.  See if two values are relatively equal.
+*  It's the developer's responsibility not to pass in the value 0, which
+*  may cause the equation to fail.
+*/
+#define VL_DBL_REL_EQUAL(X, Y, M) (fabs(((Y) - (X)) / (X)) < (M))
+
 #define DATASET_CREATE_UNDER_ROOT_DSET_NAME  "/dset_under_root"
 #define DATASET_CREATE_UNDER_ROOT_SPACE_RANK 2
 
@@ -126,15 +133,15 @@ int vol_dataset_test(void);
 #define DATASET_PROPERTY_LIST_TEST_DSET_NAME3    "property_list_test_dataset3"
 #define DATASET_PROPERTY_LIST_TEST_DSET_NAME4    "property_list_test_dataset4"
 
-#define DATASET_FILL_VALUE_TEST_DSET_NAME1          "dataset_fill_value_test_dataset1"
-#define DATASET_FILL_VALUE_TEST_DSET_NAME2          "dataset_fill_value_test_dataset2"
-#define DATASET_FILL_VALUE_TEST_DSET_NAME3          "dataset_fill_value_test_dataset3"
-#define DATASET_FILL_VALUE_TEST_INT_TYPE            H5T_NATIVE_INT
-#define DATASET_FILL_VALUE_TEST_INT_FILL_VALUE      1
-#define DATASET_FILL_VALUE_TEST_DOUBLE_TYPE         H5T_NATIVE_DOUBLE
-#define DATASET_FILL_VALUE_TEST_DOUBLE_FILL_VALUE   2.002 
-#define DATASET_FILL_VALUE_TEST_STRING_FILL_VALUE   "abcdefgh"
-#define DATASET_FILL_VALUE_TEST_STRING_SIZE         8 /* No null terminator for fixed length string*/
+#define DATASET_FILL_VALUE_TEST_DSET_NAME1        "dataset_fill_value_test_dataset1"
+#define DATASET_FILL_VALUE_TEST_DSET_NAME2        "dataset_fill_value_test_dataset2"
+#define DATASET_FILL_VALUE_TEST_DSET_NAME3        "dataset_fill_value_test_dataset3"
+#define DATASET_FILL_VALUE_TEST_INT_TYPE          H5T_NATIVE_INT
+#define DATASET_FILL_VALUE_TEST_INT_FILL_VALUE    1
+#define DATASET_FILL_VALUE_TEST_DOUBLE_TYPE       H5T_NATIVE_DOUBLE
+#define DATASET_FILL_VALUE_TEST_DOUBLE_FILL_VALUE 2.002
+#define DATASET_FILL_VALUE_TEST_STRING_FILL_VALUE "abcdefgh"
+#define DATASET_FILL_VALUE_TEST_STRING_SIZE       8 /* No null terminator for fixed length string*/
 
 #define DATASET_SMALL_READ_TEST_ALL_DSET_SPACE_RANK 3
 #define DATASET_SMALL_READ_TEST_ALL_DSET_DTYPESIZE  sizeof(int)

--- a/vol_dataset_test.h
+++ b/vol_dataset_test.h
@@ -24,10 +24,10 @@ int vol_dataset_test(void);
  ************************************************/
 
 /* Check if the relative difference is smaller than a
-*  predefined value M.  See if two values are relatively equal.
-*  It's the developer's responsibility not to pass in the value 0, which
-*  may cause the equation to fail.
-*/
+ *  predefined value M.  See if two values are relatively equal.
+ *  It's the developer's responsibility not to pass in the value 0, which
+ *  may cause the equation to fail.
+ */
 #define VL_DBL_REL_EQUAL(X, Y, M) (fabs(((Y) - (X)) / (X)) < (M))
 
 #define DATASET_CREATE_UNDER_ROOT_DSET_NAME  "/dset_under_root"


### PR DESCRIPTION
Currently only tests that fill values work for integers, doubles, and fixed-length strings with ASCII characters, since not all VOLs support more complex datatypes. 