### PR TITLE
ci: fix invalid 'ctest --build' invocation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -228,5 +228,5 @@ jobs:
       - name: Run API tests
         run: |
           cd "$GITHUB_WORKSPACE/api-tests/build"
-          ctest --build . --parallel 2 -C ${{ matrix.build_mode.cmake }} -V
+          ctest --parallel 2 -C ${{ matrix.build_mode.cmake }} -V
         if: (matrix.run_tests)


### PR DESCRIPTION
## Summary

The "Run API tests" step in \`main.yml\` calls \`ctest --build . --parallel 2 -C ... -V\`, but \`--build\` is a \`cmake\` flag, not a \`ctest\` one:

\`\`\`
CMake Error: Unknown argument: --build
CMake Error: Run 'ctest --help' for all supported options.
\`\`\`

The actual build already happens in the preceding "Build/Install" step via \`cmake --build\`. This was failing the \`Ubuntu GCC DBG\` job outright on every run, and - via this workflow's fail-fast matrix strategy - cancelling every other job in the same run before they could report their own real status. Confirmed this includes the \`-Werror\` builds, which actually compile cleanly (100% of targets built) when allowed to run to completion.

## Test plan

- [x] Ran the corrected command locally against the syntax (`ctest --parallel 2 -C <mode> -V`) to confirm it's valid `ctest` usage.
- [ ] Would appreciate a maintainer confirming this fixes the `Ubuntu GCC DBG` job and lets the rest of the matrix report real results.