### PR TITLE
Handle H5T_COMPLEX (HDF5 2.0) in generate_random_datatype

### DIFF
--- a/vol_test_util.c
+++ b/vol_test_util.c
@@ -166,6 +166,12 @@ roll_datatype:
 
             gen_func = generate_random_datatype_array;
             break;
+#if H5_VERSION_GE(2, 0, 0)
+        case H5T_COMPLEX:
+            /* Complex number datatypes are unsupported, try again */
+            goto roll_datatype;
+            break;
+#endif
         default:
             HDprintf("    invalid datatype class\n");
             goto done;


### PR DESCRIPTION
## Summary

HDF5 2.0 (tracked by the \`develop\` branch) adds a new datatype class, \`H5T_COMPLEX\` (native complex-number support), bumping \`H5T_NCLASSES\` from 11 to 12. \`generate_random_datatype()\`'s \`rand() % H5T_NCLASSES\` roll had no case for the new value, falling through to the \`default:\` "invalid datatype class" error path and returning an invalid datatype - breaking every subsequent test in a run that happened to roll a complex type (discovered while running [HDFGroup/vol-daos](https://github.com/HDFGroup/vol-daos)'s CI against HDF5 \`develop\`).

Adds a case treating it like the other currently-unsupported classes (\`H5T_TIME\`, \`H5T_BITFIELD\`, \`H5T_OPAQUE\`, \`H5T_VLEN\`): retry with a different random class. Version-gated since \`H5T_COMPLEX\` doesn't exist as a symbol pre-2.0.

## Test plan

- [ ] Would appreciate a maintainer confirming this against a real HDF5 \`develop\` build - I've verified the version-gating compiles correctly against both pre-2.0 and 2.0-era headers, but haven't run the suite against `develop` end-to-end from this exact repo.